### PR TITLE
feat: add graph endpoints for managing graphs, nodes, edges, and trav…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,112 @@
-# forge
-Forge - build something trial project
+# Forge
+
+Forge - A graph management trial project built with Spring Boot.
+
+## Overview
+
+Forge provides a REST API for managing graphs with nodes and edges, supporting depth-first and breadth-first traversals using an immutable graph data structure.
+
+## Features
+
+- Create, read, and delete graphs
+- Add nodes to graphs
+- Create edges between nodes
+- Perform depth-first search (DFS) traversals
+- Perform breadth-first search (BFS) traversals
+- Immutable graph data structure for thread-safety
+
+## API Endpoints
+
+### Graphs
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/graphs` | List all graphs (id, name) |
+| GET | `/graphs/{id}` | Get a specific graph by ID |
+| POST | `/graphs` | Create a new graph with a name |
+| DELETE | `/graphs/{id}` | Delete a graph by ID |
+
+### Nodes
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/graphs/{id}/nodes` | List all nodes in a graph |
+| POST | `/graphs/{id}/nodes` | Create a new node in a graph |
+| GET | `/graphs/{id}/nodes/{nodeId}` | Get a specific node by ID |
+
+### Edges
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/graphs/{id}/nodes/{fromId}/{toId}` | Add an edge from node fromId to toId |
+
+### Graph Traversals
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/graphs/{id}/dfs/{nodeId}` | Depth-first search from nodeId, returns list of visited nodes |
+| GET | `/graphs/{id}/bfs/{nodeId}` | Breadth-first search from nodeId, returns list of visited nodes |
+
+## Request/Response Examples
+
+### Create a Graph
+
+```bash
+curl -X POST http://localhost:8080/graphs \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My Graph"}'
+```
+
+Response:
+```json
+{"id": 1, "name": "My Graph"}
+```
+
+### Add Nodes
+
+```bash
+curl -X POST http://localhost:8080/graphs/1/nodes \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Node A"}'
+```
+
+### Add Edge
+
+```bash
+curl -X POST http://localhost:8080/graphs/1/nodes/0/1
+```
+
+### Perform DFS
+
+```bash
+curl http://localhost:8080/graphs/1/dfs/0
+```
+
+Response:
+```json
+[{"id": 1, "name": "Node A"}, {"id": 2, "name": "Node B"}]
+```
+
+## Technology Stack
+
+- Java 17
+- Spring Boot 3.4.1
+- Spring Data JPA
+- H2 Database (in-memory)
+- jMolecules DDD
+
+## Building and Running
+
+```bash
+# Build the project
+mvn clean install
+
+# Run the application
+mvn spring-boot:run
+```
+
+The application will start on `http://localhost:8080`.
+
+## License
+
+Apache License 2.0

--- a/src/main/java/com/robsartin/graphs/application/GraphController.java
+++ b/src/main/java/com/robsartin/graphs/application/GraphController.java
@@ -1,0 +1,240 @@
+package com.robsartin.graphs.application;
+
+import com.robsartin.graphs.domain.models.Graph;
+import com.robsartin.graphs.domain.models.GraphNode;
+import com.robsartin.graphs.domain.ports.out.GraphRepository;
+import com.robsartin.graphs.infrastructure.ImmutableGraph;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * REST Controller for managing graphs.
+ * Handles HTTP requests for graph operations including nodes, edges, and traversals.
+ */
+@RestController
+@RequestMapping("/graphs")
+public class GraphController {
+
+    private final GraphRepository graphRepository;
+
+    public GraphController(GraphRepository graphRepository) {
+        this.graphRepository = graphRepository;
+    }
+
+    /**
+     * GET /graphs - Retrieves all graphs
+     *
+     * @return list of all graphs (id and name)
+     */
+    @GetMapping
+    public List<GraphSummaryResponse> getAllGraphs() {
+        return graphRepository.findAll().stream()
+                .map(g -> new GraphSummaryResponse(g.getId(), g.getName()))
+                .toList();
+    }
+
+    /**
+     * GET /graphs/{id} - Retrieves a specific graph by ID
+     *
+     * @param id the graph ID
+     * @return the graph if found, 404 if not found
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<GraphSummaryResponse> getGraphById(@PathVariable Integer id) {
+        return graphRepository.findById(id)
+                .map(g -> ResponseEntity.ok(new GraphSummaryResponse(g.getId(), g.getName())))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * POST /graphs - Creates a new graph
+     *
+     * @param request the graph creation request
+     * @return the created graph with HTTP 201 status
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public GraphSummaryResponse createGraph(@Valid @RequestBody CreateGraphRequest request) {
+        Graph graph = new Graph(request.name());
+        Graph savedGraph = graphRepository.save(graph);
+        return new GraphSummaryResponse(savedGraph.getId(), savedGraph.getName());
+    }
+
+    /**
+     * DELETE /graphs/{id} - Deletes a graph by ID
+     *
+     * @param id the graph ID to delete
+     * @return 204 No Content if deleted, 404 if not found
+     */
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteGraph(@PathVariable Integer id) {
+        if (!graphRepository.existsById(id)) {
+            return ResponseEntity.notFound().build();
+        }
+        graphRepository.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * GET /graphs/{id}/nodes - Retrieves all nodes in a graph
+     *
+     * @param id the graph ID
+     * @return list of all nodes in the graph
+     */
+    @GetMapping("/{id}/nodes")
+    public ResponseEntity<List<NodeResponse>> getAllNodes(@PathVariable Integer id) {
+        return graphRepository.findById(id)
+                .map(graph -> {
+                    List<NodeResponse> nodes = graph.getNodes().stream()
+                            .map(n -> new NodeResponse(n.getId(), n.getName()))
+                            .toList();
+                    return ResponseEntity.ok(nodes);
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * POST /graphs/{id}/nodes - Creates a new node in a graph
+     *
+     * @param id the graph ID
+     * @param request the node creation request
+     * @return the created node with HTTP 201 status
+     */
+    @PostMapping("/{id}/nodes")
+    public ResponseEntity<NodeResponse> createNode(@PathVariable Integer id,
+                                                   @Valid @RequestBody CreateNodeRequest request) {
+        return graphRepository.findById(id)
+                .map(graph -> {
+                    GraphNode node = graph.addNode(request.name());
+                    Graph savedGraph = graphRepository.save(graph);
+                    GraphNode savedNode = savedGraph.getNodes().stream()
+                            .filter(n -> n.getName().equals(request.name()))
+                            .reduce((first, second) -> second)
+                            .orElse(node);
+                    return ResponseEntity.status(HttpStatus.CREATED)
+                            .body(new NodeResponse(savedNode.getId(), savedNode.getName()));
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * GET /graphs/{id}/nodes/{nodeId} - Retrieves a specific node by ID
+     *
+     * @param id the graph ID
+     * @param nodeId the node ID
+     * @return the node if found, 404 if not found
+     */
+    @GetMapping("/{id}/nodes/{nodeId}")
+    public ResponseEntity<NodeResponse> getNodeById(@PathVariable Integer id,
+                                                    @PathVariable Integer nodeId) {
+        return graphRepository.findById(id)
+                .flatMap(graph -> graph.getNodes().stream()
+                        .filter(n -> n.getId().equals(nodeId))
+                        .findFirst()
+                        .map(n -> ResponseEntity.ok(new NodeResponse(n.getId(), n.getName()))))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * POST /graphs/{id}/nodes/{fromId}/{toId} - Adds an edge between two nodes
+     *
+     * @param id the graph ID
+     * @param fromId the source node graph ID
+     * @param toId the target node graph ID
+     * @return 200 OK if edge added, 404 if graph not found
+     */
+    @PostMapping("/{id}/nodes/{fromId}/{toId}")
+    public ResponseEntity<Void> addEdge(@PathVariable Integer id,
+                                        @PathVariable Integer fromId,
+                                        @PathVariable Integer toId) {
+        return graphRepository.findById(id)
+                .map(graph -> {
+                    graph.addEdge(fromId, toId);
+                    graphRepository.save(graph);
+                    return ResponseEntity.ok().<Void>build();
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * GET /graphs/{id}/dfs/{nodeId} - Performs depth-first search from a node
+     *
+     * @param id the graph ID
+     * @param nodeId the starting node graph ID
+     * @return list of nodes visited in DFS order
+     */
+    @GetMapping("/{id}/dfs/{nodeId}")
+    public ResponseEntity<List<NodeResponse>> depthFirstSearch(@PathVariable Integer id,
+                                                               @PathVariable Integer nodeId) {
+        return graphRepository.findById(id)
+                .map(graph -> {
+                    List<NodeResponse> visited = new ArrayList<>();
+                    graph.getImmutableGraph().depthFirstTraversal(nodeId, context -> {
+                        GraphNode node = graph.findNodeByGraphNodeId(context.getNodeId());
+                        if (node != null) {
+                            visited.add(new NodeResponse(node.getId(), node.getName()));
+                        } else {
+                            visited.add(new NodeResponse(context.getNodeId(), context.getLabel()));
+                        }
+                    });
+                    return ResponseEntity.ok(visited);
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * GET /graphs/{id}/bfs/{nodeId} - Performs breadth-first search from a node
+     *
+     * @param id the graph ID
+     * @param nodeId the starting node graph ID
+     * @return list of nodes visited in BFS order
+     */
+    @GetMapping("/{id}/bfs/{nodeId}")
+    public ResponseEntity<List<NodeResponse>> breadthFirstSearch(@PathVariable Integer id,
+                                                                 @PathVariable Integer nodeId) {
+        return graphRepository.findById(id)
+                .map(graph -> {
+                    List<NodeResponse> visited = new ArrayList<>();
+                    graph.getImmutableGraph().breadthFirstTraversal(nodeId, context -> {
+                        GraphNode node = graph.findNodeByGraphNodeId(context.getNodeId());
+                        if (node != null) {
+                            visited.add(new NodeResponse(node.getId(), node.getName()));
+                        } else {
+                            visited.add(new NodeResponse(context.getNodeId(), context.getLabel()));
+                        }
+                    });
+                    return ResponseEntity.ok(visited);
+                })
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Request DTO for creating a graph
+     */
+    public record CreateGraphRequest(@NotBlank(message = "Name is required") String name) {
+    }
+
+    /**
+     * Request DTO for creating a node
+     */
+    public record CreateNodeRequest(@NotBlank(message = "Name is required") String name) {
+    }
+
+    /**
+     * Response DTO for graph summary
+     */
+    public record GraphSummaryResponse(Integer id, String name) {
+    }
+
+    /**
+     * Response DTO for node
+     */
+    public record NodeResponse(Integer id, String name) {
+    }
+}

--- a/src/main/java/com/robsartin/graphs/domain/models/Graph.java
+++ b/src/main/java/com/robsartin/graphs/domain/models/Graph.java
@@ -1,0 +1,115 @@
+package com.robsartin.graphs.domain.models;
+
+import com.robsartin.graphs.infrastructure.ImmutableGraph;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Table(name = "graphs")
+public class Graph {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "graph", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GraphNode> nodes = new ArrayList<>();
+
+    @Transient
+    private ImmutableGraph<String, String> immutableGraph = new ImmutableGraph<>();
+
+    protected Graph() {
+        // JPA requires a no-arg constructor
+    }
+
+    public Graph(String name) {
+        this.name = name;
+        this.immutableGraph = new ImmutableGraph<>();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<GraphNode> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<GraphNode> nodes) {
+        this.nodes = nodes;
+    }
+
+    public ImmutableGraph<String, String> getImmutableGraph() {
+        return immutableGraph;
+    }
+
+    public void setImmutableGraph(ImmutableGraph<String, String> immutableGraph) {
+        this.immutableGraph = immutableGraph;
+    }
+
+    public GraphNode addNode(String nodeName) {
+        ImmutableGraph.GraphWithNode<String, String> result = immutableGraph.addNode(nodeName);
+        this.immutableGraph = result.getGraph();
+        GraphNode node = new GraphNode(nodeName, result.getNodeId());
+        node.setGraph(this);
+        this.nodes.add(node);
+        return node;
+    }
+
+    public void addEdge(int fromNodeId, int toNodeId) {
+        this.immutableGraph = this.immutableGraph.addEdge(fromNodeId, toNodeId, "edge");
+    }
+
+    public GraphNode findNodeByGraphNodeId(int graphNodeId) {
+        return nodes.stream()
+                .filter(n -> n.getGraphNodeId() != null && n.getGraphNodeId() == graphNodeId)
+                .findFirst()
+                .orElse(null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Graph graph = (Graph) o;
+        return Objects.equals(id, graph.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "Graph{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", nodeCount=" + nodes.size() +
+                '}';
+    }
+}

--- a/src/main/java/com/robsartin/graphs/domain/models/GraphNode.java
+++ b/src/main/java/com/robsartin/graphs/domain/models/GraphNode.java
@@ -1,0 +1,95 @@
+package com.robsartin.graphs.domain.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.util.Objects;
+
+@Entity
+@Table(name = "graph_nodes")
+public class GraphNode {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+
+    private Integer graphNodeId;
+
+    @ManyToOne
+    @JoinColumn(name = "graph_id")
+    private Graph graph;
+
+    protected GraphNode() {
+        // JPA requires a no-arg constructor
+    }
+
+    public GraphNode(String name) {
+        this.name = name;
+    }
+
+    public GraphNode(String name, Integer graphNodeId) {
+        this.name = name;
+        this.graphNodeId = graphNodeId;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getGraphNodeId() {
+        return graphNodeId;
+    }
+
+    public void setGraphNodeId(Integer graphNodeId) {
+        this.graphNodeId = graphNodeId;
+    }
+
+    public Graph getGraph() {
+        return graph;
+    }
+
+    public void setGraph(Graph graph) {
+        this.graph = graph;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GraphNode graphNode = (GraphNode) o;
+        return Objects.equals(id, graphNode.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "GraphNode{" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", graphNodeId=" + graphNodeId +
+                '}';
+    }
+}

--- a/src/main/java/com/robsartin/graphs/domain/ports/out/GraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/domain/ports/out/GraphRepository.java
@@ -1,0 +1,52 @@
+package com.robsartin.graphs.domain.ports.out;
+
+import com.robsartin.graphs.domain.models.Graph;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Port for Graph persistence operations.
+ * This interface defines the contract for storing and retrieving graphs,
+ * independent of the actual persistence mechanism.
+ */
+public interface GraphRepository {
+
+    /**
+     * Saves a graph to the repository.
+     *
+     * @param graph the graph to save
+     * @return the saved graph with generated ID
+     */
+    Graph save(Graph graph);
+
+    /**
+     * Finds a graph by its ID.
+     *
+     * @param id the graph ID
+     * @return an Optional containing the graph if found, or empty if not found
+     */
+    Optional<Graph> findById(Integer id);
+
+    /**
+     * Retrieves all graphs from the repository.
+     *
+     * @return a list of all graphs
+     */
+    List<Graph> findAll();
+
+    /**
+     * Deletes a graph by its ID.
+     *
+     * @param id the graph ID to delete
+     */
+    void deleteById(Integer id);
+
+    /**
+     * Checks if a graph exists with the given ID.
+     *
+     * @param id the graph ID
+     * @return true if a graph exists, false otherwise
+     */
+    boolean existsById(Integer id);
+}

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapter.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapter.java
@@ -1,0 +1,47 @@
+package com.robsartin.graphs.infrastructure.adapters.persistence;
+
+import com.robsartin.graphs.domain.models.Graph;
+import com.robsartin.graphs.domain.ports.out.GraphRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adapter that implements the GraphRepository port using Spring Data JPA.
+ * This adapter translates between the domain port interface and the JPA repository.
+ */
+@Component
+public class GraphRepositoryAdapter implements GraphRepository {
+
+    private final JpaGraphRepository jpaGraphRepository;
+
+    public GraphRepositoryAdapter(JpaGraphRepository jpaGraphRepository) {
+        this.jpaGraphRepository = jpaGraphRepository;
+    }
+
+    @Override
+    public Graph save(Graph graph) {
+        return jpaGraphRepository.save(graph);
+    }
+
+    @Override
+    public Optional<Graph> findById(Integer id) {
+        return jpaGraphRepository.findById(id);
+    }
+
+    @Override
+    public List<Graph> findAll() {
+        return jpaGraphRepository.findAll();
+    }
+
+    @Override
+    public void deleteById(Integer id) {
+        jpaGraphRepository.deleteById(id);
+    }
+
+    @Override
+    public boolean existsById(Integer id) {
+        return jpaGraphRepository.existsById(id);
+    }
+}

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/JpaGraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/JpaGraphRepository.java
@@ -1,0 +1,9 @@
+package com.robsartin.graphs.infrastructure.adapters.persistence;
+
+import com.robsartin.graphs.domain.models.Graph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaGraphRepository extends JpaRepository<Graph, Integer> {
+}

--- a/src/test/java/com/robsartin/graphs/application/GraphControllerTest.java
+++ b/src/test/java/com/robsartin/graphs/application/GraphControllerTest.java
@@ -1,0 +1,364 @@
+package com.robsartin.graphs.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.robsartin.graphs.domain.models.Graph;
+import com.robsartin.graphs.domain.models.GraphNode;
+import com.robsartin.graphs.domain.ports.out.GraphRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(GraphController.class)
+class GraphControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private GraphRepository graphRepository;
+
+    // GET /graphs - list all graphs
+    @Test
+    void shouldReturnAllGraphs() throws Exception {
+        Graph graph1 = new Graph("Graph 1");
+        graph1.setId(1);
+        Graph graph2 = new Graph("Graph 2");
+        graph2.setId(2);
+        List<Graph> graphs = Arrays.asList(graph1, graph2);
+
+        when(graphRepository.findAll()).thenReturn(graphs);
+
+        mockMvc.perform(get("/graphs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Graph 1"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].name").value("Graph 2"));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoGraphs() throws Exception {
+        when(graphRepository.findAll()).thenReturn(List.of());
+
+        mockMvc.perform(get("/graphs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // GET /graphs/{id} - get graph by id
+    @Test
+    void shouldReturnGraphById() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+
+        mockMvc.perform(get("/graphs/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Test Graph"));
+    }
+
+    @Test
+    void shouldReturn404WhenGraphNotFound() throws Exception {
+        when(graphRepository.findById(999)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/graphs/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    // POST /graphs - create a new graph
+    @Test
+    void shouldCreateNewGraph() throws Exception {
+        Graph savedGraph = new Graph("New Graph");
+        savedGraph.setId(1);
+
+        when(graphRepository.save(any(Graph.class))).thenReturn(savedGraph);
+
+        mockMvc.perform(post("/graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"New Graph\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("New Graph"));
+    }
+
+    @Test
+    void shouldRejectPostWithoutName() throws Exception {
+        mockMvc.perform(post("/graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // DELETE /graphs/{id} - delete graph by id
+    @Test
+    void shouldDeleteGraphById() throws Exception {
+        when(graphRepository.existsById(1)).thenReturn(true);
+        doNothing().when(graphRepository).deleteById(1);
+
+        mockMvc.perform(delete("/graphs/1"))
+                .andExpect(status().isNoContent());
+
+        verify(graphRepository).deleteById(1);
+    }
+
+    @Test
+    void shouldReturn404WhenDeletingNonExistentGraph() throws Exception {
+        when(graphRepository.existsById(999)).thenReturn(false);
+
+        mockMvc.perform(delete("/graphs/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    // GET /graphs/{id}/nodes - list all nodes in a graph
+    @Test
+    void shouldReturnAllNodesInGraph() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+        GraphNode node1 = new GraphNode("Node A", 0);
+        node1.setId(1);
+        node1.setGraph(graph);
+        GraphNode node2 = new GraphNode("Node B", 1);
+        node2.setId(2);
+        node2.setGraph(graph);
+        graph.getNodes().add(node1);
+        graph.getNodes().add(node2);
+
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+
+        mockMvc.perform(get("/graphs/1/nodes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Node A"))
+                .andExpect(jsonPath("$[1].id").value(2))
+                .andExpect(jsonPath("$[1].name").value("Node B"));
+    }
+
+    @Test
+    void shouldReturn404WhenListingNodesForNonExistentGraph() throws Exception {
+        when(graphRepository.findById(999)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/graphs/999/nodes"))
+                .andExpect(status().isNotFound());
+    }
+
+    // POST /graphs/{id}/nodes - create a new node in a graph
+    @Test
+    void shouldCreateNewNodeInGraph() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+
+        Graph savedGraph = new Graph("Test Graph");
+        savedGraph.setId(1);
+        GraphNode node = new GraphNode("New Node", 0);
+        node.setId(1);
+        node.setGraph(savedGraph);
+        savedGraph.getNodes().add(node);
+
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+        when(graphRepository.save(any(Graph.class))).thenReturn(savedGraph);
+
+        mockMvc.perform(post("/graphs/1/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"New Node\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("New Node"));
+    }
+
+    @Test
+    void shouldReturn404WhenCreatingNodeInNonExistentGraph() throws Exception {
+        when(graphRepository.findById(999)).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/graphs/999/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"New Node\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldRejectNodeCreationWithoutName() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+
+        mockMvc.perform(post("/graphs/1/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // GET /graphs/{id}/nodes/{nodeId} - get a specific node
+    @Test
+    void shouldReturnNodeById() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+        GraphNode node = new GraphNode("Node A", 0);
+        node.setId(5);
+        node.setGraph(graph);
+        graph.getNodes().add(node);
+
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+
+        mockMvc.perform(get("/graphs/1/nodes/5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.name").value("Node A"));
+    }
+
+    @Test
+    void shouldReturn404WhenNodeNotFoundInGraph() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+
+        mockMvc.perform(get("/graphs/1/nodes/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    // POST /graphs/{id}/nodes/{fromId}/{toId} - add an edge
+    @Test
+    void shouldAddEdgeBetweenNodes() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+        GraphNode node1 = new GraphNode("Node A", 0);
+        node1.setId(1);
+        node1.setGraph(graph);
+        GraphNode node2 = new GraphNode("Node B", 1);
+        node2.setId(2);
+        node2.setGraph(graph);
+        graph.getNodes().add(node1);
+        graph.getNodes().add(node2);
+        // Initialize the immutable graph with nodes
+        graph.setImmutableGraph(graph.getImmutableGraph().addNode("Node A").getGraph());
+        graph.setImmutableGraph(graph.getImmutableGraph().addNode("Node B").getGraph());
+
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+        when(graphRepository.save(any(Graph.class))).thenReturn(graph);
+
+        mockMvc.perform(post("/graphs/1/nodes/0/1"))
+                .andExpect(status().isOk());
+
+        verify(graphRepository).save(any(Graph.class));
+    }
+
+    @Test
+    void shouldReturn404WhenAddingEdgeToNonExistentGraph() throws Exception {
+        when(graphRepository.findById(999)).thenReturn(Optional.empty());
+
+        mockMvc.perform(post("/graphs/999/nodes/0/1"))
+                .andExpect(status().isNotFound());
+    }
+
+    // GET /graphs/{id}/dfs/{nodeId} - depth-first search
+    @Test
+    void shouldPerformDepthFirstSearch() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+        GraphNode node1 = new GraphNode("Node A", 0);
+        node1.setId(1);
+        GraphNode node2 = new GraphNode("Node B", 1);
+        node2.setId(2);
+        GraphNode node3 = new GraphNode("Node C", 2);
+        node3.setId(3);
+        node1.setGraph(graph);
+        node2.setGraph(graph);
+        node3.setGraph(graph);
+        graph.getNodes().add(node1);
+        graph.getNodes().add(node2);
+        graph.getNodes().add(node3);
+
+        // Build the immutable graph: A -> B -> C
+        var result1 = graph.getImmutableGraph().addNode("Node A");
+        graph.setImmutableGraph(result1.getGraph());
+        var result2 = graph.getImmutableGraph().addNode("Node B");
+        graph.setImmutableGraph(result2.getGraph());
+        var result3 = graph.getImmutableGraph().addNode("Node C");
+        graph.setImmutableGraph(result3.getGraph());
+        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(0, 1, "edge"));
+        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(1, 2, "edge"));
+
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+
+        mockMvc.perform(get("/graphs/1/dfs/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(3));
+    }
+
+    @Test
+    void shouldReturn404WhenDFSOnNonExistentGraph() throws Exception {
+        when(graphRepository.findById(999)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/graphs/999/dfs/0"))
+                .andExpect(status().isNotFound());
+    }
+
+    // GET /graphs/{id}/bfs/{nodeId} - breadth-first search
+    @Test
+    void shouldPerformBreadthFirstSearch() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        graph.setId(1);
+        GraphNode node1 = new GraphNode("Node A", 0);
+        node1.setId(1);
+        GraphNode node2 = new GraphNode("Node B", 1);
+        node2.setId(2);
+        GraphNode node3 = new GraphNode("Node C", 2);
+        node3.setId(3);
+        node1.setGraph(graph);
+        node2.setGraph(graph);
+        node3.setGraph(graph);
+        graph.getNodes().add(node1);
+        graph.getNodes().add(node2);
+        graph.getNodes().add(node3);
+
+        // Build the immutable graph: A -> B -> C
+        var result1 = graph.getImmutableGraph().addNode("Node A");
+        graph.setImmutableGraph(result1.getGraph());
+        var result2 = graph.getImmutableGraph().addNode("Node B");
+        graph.setImmutableGraph(result2.getGraph());
+        var result3 = graph.getImmutableGraph().addNode("Node C");
+        graph.setImmutableGraph(result3.getGraph());
+        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(0, 1, "edge"));
+        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(1, 2, "edge"));
+
+        when(graphRepository.findById(1)).thenReturn(Optional.of(graph));
+
+        mockMvc.perform(get("/graphs/1/bfs/0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(3));
+    }
+
+    @Test
+    void shouldReturn404WhenBFSOnNonExistentGraph() throws Exception {
+        when(graphRepository.findById(999)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/graphs/999/bfs/0"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
…ersals

- Add Graph and GraphNode domain entities with JPA persistence
- Create GraphRepository port interface and adapter for hexagonal architecture
- Implement GraphController with REST endpoints:
  - GET/POST/DELETE /graphs for graph CRUD operations
  - GET/POST /graphs/{id}/nodes for node management
  - POST /graphs/{id}/nodes/{fromId}/{toId} for edge creation
  - GET /graphs/{id}/dfs/{nodeId} for depth-first search traversal
  - GET /graphs/{id}/bfs/{nodeId} for breadth-first search traversal
- Add comprehensive unit tests for GraphController (TDD approach)
- Update README.md with API documentation and usage examples