### PR TITLE
fix: change domain dependency rule from infrastructure to application

### DIFF
--- a/src/test/java/com/robsartin/graphs/DddPatternsTest.java
+++ b/src/test/java/com/robsartin/graphs/DddPatternsTest.java
@@ -44,11 +44,11 @@ class DddPatternsTest {
         }
 
         @Test
-        @DisplayName("domain classes should not depend on infrastructure")
-        void domainShouldNotDependOnInfrastructure() {
+        @DisplayName("domain classes should not depend on application")
+        void domainShouldNotDependOnApplication() {
             noClasses()
                     .that().resideInAPackage("com.robsartin.graphs.domain..")
-                    .should().dependOnClassesThat().resideInAPackage("com.robsartin.graphs.infrastructure..")
+                    .should().dependOnClassesThat().resideInAPackage("com.robsartin.graphs.application..")
                     .allowEmptyShould(true)
                     .check(allClasses);
         }


### PR DESCRIPTION
Domain classes may now depend on infrastructure classes, but should not depend on application layer classes to maintain proper layered architecture.