### PR TITLE
fix: reconstruct ImmutableGraph after loading Graph from database

### DIFF
--- a/src/main/java/com/robsartin/graphs/domain/models/Graph.java
+++ b/src/main/java/com/robsartin/graphs/domain/models/Graph.java
@@ -7,10 +7,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PostLoad;
 import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -89,6 +91,18 @@ public class Graph {
                 .filter(n -> n.getGraphNodeId() != null && n.getGraphNodeId() == graphNodeId)
                 .findFirst()
                 .orElse(null);
+    }
+
+    @PostLoad
+    private void reconstructImmutableGraph() {
+        this.immutableGraph = new ImmutableGraph<>();
+        nodes.stream()
+                .filter(n -> n.getGraphNodeId() != null)
+                .sorted(Comparator.comparing(GraphNode::getGraphNodeId))
+                .forEach(node -> {
+                    ImmutableGraph.GraphWithNode<String, String> result = immutableGraph.addNode(node.getName());
+                    this.immutableGraph = result.getGraph();
+                });
     }
 
     @Override


### PR DESCRIPTION
The ImmutableGraph field is @Transient and was not being reconstructed when a Graph entity was loaded from the database. This caused an IllegalArgumentException when calling addEdge() because the nodes didn't exist in the empty ImmutableGraph.

Added a @PostLoad lifecycle callback that reconstructs the ImmutableGraph by re-adding all persisted nodes in order of their graphNodeId.