### PR TITLE
refactor: replace field @Autowired with constructor DI in test classes

### DIFF
--- a/src/test/java/com/robsartin/graphs/application/GraphControllerTest.java
+++ b/src/test/java/com/robsartin/graphs/application/GraphControllerTest.java
@@ -25,14 +25,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(GraphController.class)
 class GraphControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final MockMvc mockMvc;
+    private final ObjectMapper objectMapper;
 
     @MockBean
     private GraphRepository graphRepository;
+
+    @Autowired
+    GraphControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+    }
 
     // GET /graphs - list all graphs
     @Test

--- a/src/test/java/com/robsartin/graphs/application/ItemControllerIntegrationTest.java
+++ b/src/test/java/com/robsartin/graphs/application/ItemControllerIntegrationTest.java
@@ -23,14 +23,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class ItemControllerIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+    private final MockMvc mockMvc;
+    private final ObjectMapper objectMapper;
+    private final ItemRepository itemRepository;
 
     @Autowired
-    private ObjectMapper objectMapper;
-
-    @Autowired
-    private ItemRepository itemRepository;
+    ItemControllerIntegrationTest(MockMvc mockMvc, ObjectMapper objectMapper, ItemRepository itemRepository) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+        this.itemRepository = itemRepository;
+    }
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/com/robsartin/graphs/application/ItemControllerTest.java
+++ b/src/test/java/com/robsartin/graphs/application/ItemControllerTest.java
@@ -24,14 +24,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(ItemController.class)
 class ItemControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final MockMvc mockMvc;
+    private final ObjectMapper objectMapper;
 
     @MockBean
     private ItemRepository itemRepository;
+
+    @Autowired
+    ItemControllerTest(MockMvc mockMvc, ObjectMapper objectMapper) {
+        this.mockMvc = mockMvc;
+        this.objectMapper = objectMapper;
+    }
 
     @Test
     void shouldReturnAllItems() throws Exception {


### PR DESCRIPTION
Converted field-level @Autowired annotations to constructor-based dependency injection in test classes for better testability and explicit dependencies. MockBean fields are retained as field annotations since that is the standard pattern for Spring Boot test mocks.