### PR TITLE
feat: add deleteAll method to GraphRepository

### DIFF
--- a/src/main/java/com/robsartin/graphs/domain/ports/out/GraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/domain/ports/out/GraphRepository.java
@@ -49,4 +49,9 @@ public interface GraphRepository {
      * @return true if a graph exists, false otherwise
      */
     boolean existsById(Integer id);
+
+    /**
+     * Deletes all graphs from the repository.
+     */
+    void deleteAll();
 }

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapter.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapter.java
@@ -44,4 +44,9 @@ public class GraphRepositoryAdapter implements GraphRepository {
     public boolean existsById(Integer id) {
         return jpaGraphRepository.existsById(id);
     }
+
+    @Override
+    public void deleteAll() {
+        jpaGraphRepository.deleteAll();
+    }
 }


### PR DESCRIPTION
Add deleteAll() method to the GraphRepository interface and its implementation in GraphRepositoryAdapter. This method is needed by tests for cleanup in @BeforeEach.