### PR TITLE
feat: add OpenFeature for feature flags to protect DELETE endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jmolecules.version>1.10.0</jmolecules.version>
         <archunit.version>1.3.0</archunit.version>
+        <openfeature.version>1.12.0</openfeature.version>
     </properties>
 
     <dependencies>
@@ -51,6 +52,13 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
+        </dependency>
+
+        <!-- OpenFeature -->
+        <dependency>
+            <groupId>dev.openfeature</groupId>
+            <artifactId>sdk</artifactId>
+            <version>${openfeature.version}</version>
         </dependency>
 
         <!-- jMolecules -->

--- a/src/main/java/com/robsartin/graphs/application/GraphController.java
+++ b/src/main/java/com/robsartin/graphs/application/GraphController.java
@@ -1,5 +1,6 @@
 package com.robsartin.graphs.application;
 
+import com.robsartin.graphs.infrastructure.FeatureFlagService;
 import com.robsartin.graphs.models.Graph;
 import com.robsartin.graphs.models.GraphNode;
 import com.robsartin.graphs.ports.out.GraphRepository;
@@ -21,9 +22,11 @@ import java.util.List;
 public class GraphController {
 
     private final GraphRepository graphRepository;
+    private final FeatureFlagService featureFlagService;
 
-    public GraphController(GraphRepository graphRepository) {
+    public GraphController(GraphRepository graphRepository, FeatureFlagService featureFlagService) {
         this.graphRepository = graphRepository;
+        this.featureFlagService = featureFlagService;
     }
 
     /**
@@ -93,10 +96,13 @@ public class GraphController {
      * DELETE /graphs/{id} - Deletes a graph by ID
      *
      * @param id the graph ID to delete
-     * @return 204 No Content if deleted, 404 if not found
+     * @return 204 No Content if deleted, 404 if not found, 403 if delete is disabled
      */
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteGraph(@PathVariable Integer id) {
+        if (!featureFlagService.isDeleteEnabled()) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         if (!graphRepository.existsById(id)) {
             return ResponseEntity.notFound().build();
         }

--- a/src/main/java/com/robsartin/graphs/config/OpenFeatureConfiguration.java
+++ b/src/main/java/com/robsartin/graphs/config/OpenFeatureConfiguration.java
@@ -1,0 +1,45 @@
+package com.robsartin.graphs.config;
+
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.providers.memory.Flag;
+import dev.openfeature.sdk.providers.memory.InMemoryProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+/**
+ * Configuration for OpenFeature feature flag management.
+ *
+ * This configuration sets up the OpenFeature SDK with an in-memory provider
+ * for feature flags. In production, this could be replaced with a provider
+ * backed by LaunchDarkly, Split, Flagsmith, or other feature flag services.
+ */
+@Configuration
+public class OpenFeatureConfiguration {
+
+    public static final String FLAG_DELETE_ENABLED = "graph-delete-enabled";
+
+    @Bean
+    public OpenFeatureAPI openFeatureAPI() {
+        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+
+        Map<String, Flag<?>> flags = Map.of(
+                FLAG_DELETE_ENABLED, Flag.builder()
+                        .variant("on", true)
+                        .variant("off", false)
+                        .defaultVariant("off")
+                        .build()
+        );
+
+        api.setProviderAndWait(new InMemoryProvider(flags));
+
+        return api;
+    }
+
+    @Bean
+    public Client openFeatureClient(OpenFeatureAPI api) {
+        return api.getClient();
+    }
+}

--- a/src/main/java/com/robsartin/graphs/infrastructure/FeatureFlagService.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/FeatureFlagService.java
@@ -1,0 +1,31 @@
+package com.robsartin.graphs.infrastructure;
+
+import com.robsartin.graphs.config.OpenFeatureConfiguration;
+import dev.openfeature.sdk.Client;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service for accessing feature flags via OpenFeature.
+ *
+ * This service provides a clean interface for checking feature flags
+ * throughout the application. It wraps the OpenFeature Client to provide
+ * type-safe methods for specific feature flags.
+ */
+@Service
+public class FeatureFlagService {
+
+    private final Client client;
+
+    public FeatureFlagService(Client client) {
+        this.client = client;
+    }
+
+    /**
+     * Checks if the graph delete functionality is enabled.
+     *
+     * @return true if graph deletion is enabled, false otherwise
+     */
+    public boolean isDeleteEnabled() {
+        return client.getBooleanValue(OpenFeatureConfiguration.FLAG_DELETE_ENABLED, false);
+    }
+}

--- a/src/test/java/com/robsartin/graphs/application/GraphControllerDeleteFeatureFlagTest.java
+++ b/src/test/java/com/robsartin/graphs/application/GraphControllerDeleteFeatureFlagTest.java
@@ -1,0 +1,56 @@
+package com.robsartin.graphs.application;
+
+import com.robsartin.graphs.models.Graph;
+import com.robsartin.graphs.ports.out.GraphRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Tests for the delete graph endpoint with the feature flag disabled (default).
+ *
+ * This test uses the default OpenFeature configuration where the delete flag is disabled,
+ * ensuring that delete operations are properly protected by the feature flag.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class GraphControllerDeleteFeatureFlagTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private GraphRepository graphRepository;
+
+    @BeforeEach
+    void setUp() {
+        graphRepository.deleteAll();
+    }
+
+    @Test
+    void shouldReturn403WhenDeleteFlagIsDisabled() throws Exception {
+        Graph graph = new Graph("Test Graph");
+        Graph savedGraph = graphRepository.save(graph);
+
+        mockMvc.perform(delete("/graphs/" + savedGraph.getId()))
+                .andExpect(status().isForbidden());
+
+        // Verify graph was NOT deleted
+        assert graphRepository.findById(savedGraph.getId()).isPresent();
+    }
+
+    @Test
+    void shouldReturn403WhenDeletingNonExistentGraphAndFlagIsDisabled() throws Exception {
+        // Even for non-existent graphs, the flag check should come first
+        mockMvc.perform(delete("/graphs/999"))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/src/test/java/com/robsartin/graphs/application/GraphControllerTest.java
+++ b/src/test/java/com/robsartin/graphs/application/GraphControllerTest.java
@@ -1,6 +1,7 @@
 package com.robsartin.graphs.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.robsartin.graphs.config.TestOpenFeatureConfiguration;
 import com.robsartin.graphs.models.Graph;
 import com.robsartin.graphs.models.GraphNode;
 import com.robsartin.graphs.ports.out.GraphRepository;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
+@Import(TestOpenFeatureConfiguration.class)
 class GraphControllerTest {
 
     @Autowired

--- a/src/test/java/com/robsartin/graphs/config/TestOpenFeatureConfiguration.java
+++ b/src/test/java/com/robsartin/graphs/config/TestOpenFeatureConfiguration.java
@@ -1,0 +1,45 @@
+package com.robsartin.graphs.config;
+
+import dev.openfeature.sdk.Client;
+import dev.openfeature.sdk.OpenFeatureAPI;
+import dev.openfeature.sdk.providers.memory.Flag;
+import dev.openfeature.sdk.providers.memory.InMemoryProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.util.Map;
+
+/**
+ * Test configuration for OpenFeature that enables all feature flags.
+ *
+ * This configuration is used in integration tests to enable features
+ * that are disabled by default in production.
+ */
+@TestConfiguration
+public class TestOpenFeatureConfiguration {
+
+    @Bean
+    @Primary
+    public OpenFeatureAPI testOpenFeatureAPI() {
+        OpenFeatureAPI api = OpenFeatureAPI.getInstance();
+
+        Map<String, Flag<?>> flags = Map.of(
+                OpenFeatureConfiguration.FLAG_DELETE_ENABLED, Flag.builder()
+                        .variant("on", true)
+                        .variant("off", false)
+                        .defaultVariant("on")
+                        .build()
+        );
+
+        api.setProviderAndWait(new InMemoryProvider(flags));
+
+        return api;
+    }
+
+    @Bean
+    @Primary
+    public Client testOpenFeatureClient(OpenFeatureAPI api) {
+        return api.getClient();
+    }
+}


### PR DESCRIPTION
- Add OpenFeature SDK dependency (version 1.12.0) to pom.xml
- Create OpenFeatureConfiguration with in-memory provider
- Add FeatureFlagService for clean feature flag access
- Protect DELETE /graphs/{id} endpoint with graph-delete-enabled flag
- Flag defaults to false (disabled), returns 403 Forbidden when disabled
- Add TestOpenFeatureConfiguration to enable flag in existing tests
- Add GraphControllerDeleteFeatureFlagTest to verify flag protection