### PR TITLE
refactor: unify graphNodeId and nodeId to use database ID

### DIFF
--- a/src/main/java/com/robsartin/graphs/infrastructure/ImmutableGraph.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/ImmutableGraph.java
@@ -86,6 +86,25 @@ public class ImmutableGraph<N, E> {
     }
 
     /**
+     * Add a node with a specific ID and label, returns new graph
+     *
+     * @param nodeId the specific ID to use for this node
+     * @param label the label for the node
+     * @return the new graph containing the added node
+     * @throws IllegalArgumentException if a node with the given ID already exists
+     */
+    public ImmutableGraph<N, E> addNodeWithId(int nodeId, N label) {
+        if (nodes.containsKey(nodeId)) {
+            throw new IllegalArgumentException("Node with ID " + nodeId + " already exists");
+        }
+        Map<Integer, Context<N, E>> newNodes = new HashMap<>(nodes);
+        Context<N, E> context = new Context<>(nodeId, label,
+                                              Collections.emptyMap(), Collections.emptyMap());
+        newNodes.put(nodeId, context);
+        return new ImmutableGraph<>(newNodes, nextNodeId);
+    }
+
+    /**
      * Add an edge between two nodes, returns new graph
      */
     public ImmutableGraph<N, E> addEdge(int fromNode, int toNode, E edgeLabel) {

--- a/src/main/java/com/robsartin/graphs/models/Graph.java
+++ b/src/main/java/com/robsartin/graphs/models/Graph.java
@@ -12,7 +12,6 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -73,22 +72,46 @@ public class Graph {
         this.immutableGraph = immutableGraph;
     }
 
+    /**
+     * Add a node to the graph. The node is added to the nodes list but NOT
+     * to the ImmutableGraph yet, since the database ID is not available until
+     * after persistence. Call syncImmutableGraph() after saving to add persisted
+     * nodes to the ImmutableGraph.
+     */
     public GraphNode addNode(String nodeName) {
-        ImmutableGraph.GraphWithNode<String, String> result = immutableGraph.addNode(nodeName);
-        this.immutableGraph = result.getGraph();
-        GraphNode node = new GraphNode(nodeName, result.getNodeId());
+        GraphNode node = new GraphNode(nodeName);
         node.setGraph(this);
         this.nodes.add(node);
         return node;
     }
 
+    /**
+     * Synchronize the ImmutableGraph with persisted nodes.
+     * This adds any nodes that have database IDs but are not yet in the ImmutableGraph.
+     */
+    public void syncImmutableGraph() {
+        for (GraphNode node : nodes) {
+            if (node.getId() != null && !immutableGraph.containsNode(node.getId())) {
+                this.immutableGraph = this.immutableGraph.addNodeWithId(node.getId(), node.getName());
+            }
+        }
+    }
+
+    /**
+     * Add an edge between two nodes using their database IDs.
+     * Automatically syncs the ImmutableGraph before adding the edge.
+     */
     public void addEdge(int fromNodeId, int toNodeId) {
+        syncImmutableGraph();
         this.immutableGraph = this.immutableGraph.addEdge(fromNodeId, toNodeId, "edge");
     }
 
-    public GraphNode findNodeByGraphNodeId(int graphNodeId) {
+    /**
+     * Find a node by its database ID.
+     */
+    public GraphNode findNodeById(int nodeId) {
         return nodes.stream()
-                .filter(n -> n.getGraphNodeId() != null && n.getGraphNodeId() == graphNodeId)
+                .filter(n -> n.getId() != null && n.getId() == nodeId)
                 .findFirst()
                 .orElse(null);
     }
@@ -96,13 +119,11 @@ public class Graph {
     @PostLoad
     private void reconstructImmutableGraph() {
         this.immutableGraph = new ImmutableGraph<>();
-        nodes.stream()
-                .filter(n -> n.getGraphNodeId() != null)
-                .sorted(Comparator.comparing(GraphNode::getGraphNodeId))
-                .forEach(node -> {
-                    ImmutableGraph.GraphWithNode<String, String> result = immutableGraph.addNode(node.getName());
-                    this.immutableGraph = result.getGraph();
-                });
+        for (GraphNode node : nodes) {
+            if (node.getId() != null) {
+                this.immutableGraph = this.immutableGraph.addNodeWithId(node.getId(), node.getName());
+            }
+        }
     }
 
     @Override

--- a/src/main/java/com/robsartin/graphs/models/GraphNode.java
+++ b/src/main/java/com/robsartin/graphs/models/GraphNode.java
@@ -20,8 +20,6 @@ public class GraphNode {
 
     private String name;
 
-    private Integer graphNodeId;
-
     @ManyToOne
     @JoinColumn(name = "graph_id")
     private Graph graph;
@@ -32,11 +30,6 @@ public class GraphNode {
 
     public GraphNode(String name) {
         this.name = name;
-    }
-
-    public GraphNode(String name, Integer graphNodeId) {
-        this.name = name;
-        this.graphNodeId = graphNodeId;
     }
 
     public Integer getId() {
@@ -53,14 +46,6 @@ public class GraphNode {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public Integer getGraphNodeId() {
-        return graphNodeId;
-    }
-
-    public void setGraphNodeId(Integer graphNodeId) {
-        this.graphNodeId = graphNodeId;
     }
 
     public Graph getGraph() {
@@ -89,7 +74,6 @@ public class GraphNode {
         return "GraphNode{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
-                ", graphNodeId=" + graphNodeId +
                 '}';
     }
 }

--- a/src/test/java/com/robsartin/graphs/infrastructure/ImmutableGraphTest.java
+++ b/src/test/java/com/robsartin/graphs/infrastructure/ImmutableGraphTest.java
@@ -187,6 +187,96 @@ class ImmutableGraphTest {
         assertTrue(contextA.getSuccessors().containsKey(nodeB));
     }
 
+    @Test
+    @DisplayName("Add node with specific ID")
+    void testAddNodeWithSpecificId() {
+        ImmutableGraph<String, Integer> g0 = new ImmutableGraph<>();
+
+        // Add node with specific ID 42
+        ImmutableGraph<String, Integer> g1 = g0.addNodeWithId(42, "A");
+
+        assertEquals(1, g1.nodeCount());
+        assertTrue(g1.containsNode(42));
+        assertEquals("A", g1.getContext(42).getLabel());
+
+        // Original graph unchanged
+        assertEquals(0, g0.nodeCount());
+    }
+
+    @Test
+    @DisplayName("Add multiple nodes with specific IDs")
+    void testAddMultipleNodesWithSpecificIds() {
+        ImmutableGraph<String, Integer> g0 = new ImmutableGraph<>();
+
+        ImmutableGraph<String, Integer> g1 = g0.addNodeWithId(100, "A");
+        ImmutableGraph<String, Integer> g2 = g1.addNodeWithId(200, "B");
+        ImmutableGraph<String, Integer> g3 = g2.addNodeWithId(150, "C");
+
+        assertEquals(3, g3.nodeCount());
+        assertTrue(g3.containsNode(100));
+        assertTrue(g3.containsNode(200));
+        assertTrue(g3.containsNode(150));
+        assertEquals("A", g3.getContext(100).getLabel());
+        assertEquals("B", g3.getContext(200).getLabel());
+        assertEquals("C", g3.getContext(150).getLabel());
+    }
+
+    @Test
+    @DisplayName("Add edges between nodes with specific IDs")
+    void testAddEdgesBetweenNodesWithSpecificIds() {
+        ImmutableGraph<String, Integer> g0 = new ImmutableGraph<>();
+
+        ImmutableGraph<String, Integer> g1 = g0.addNodeWithId(100, "A");
+        ImmutableGraph<String, Integer> g2 = g1.addNodeWithId(200, "B");
+        ImmutableGraph<String, Integer> g3 = g2.addEdge(100, 200, 10);
+
+        var contextA = g3.getContext(100);
+        var contextB = g3.getContext(200);
+
+        assertTrue(contextA.getSuccessors().containsKey(200));
+        assertEquals(10, contextA.getSuccessors().get(200));
+        assertTrue(contextB.getPredecessors().containsKey(100));
+    }
+
+    @Test
+    @DisplayName("Traversals work with nodes added with specific IDs")
+    void testTraversalsWithSpecificNodeIds() {
+        ImmutableGraph<String, Integer> g0 = new ImmutableGraph<>();
+
+        ImmutableGraph<String, Integer> g1 = g0.addNodeWithId(100, "A");
+        ImmutableGraph<String, Integer> g2 = g1.addNodeWithId(200, "B");
+        ImmutableGraph<String, Integer> g3 = g2.addNodeWithId(300, "C");
+        ImmutableGraph<String, Integer> g4 = g3.addEdge(100, 200, 1);
+        ImmutableGraph<String, Integer> g5 = g4.addEdge(200, 300, 2);
+
+        List<String> dfsVisited = new ArrayList<>();
+        g5.depthFirstTraversal(100, ctx -> dfsVisited.add(ctx.getLabel()));
+
+        assertEquals(3, dfsVisited.size());
+        assertEquals("A", dfsVisited.get(0));
+        assertEquals("B", dfsVisited.get(1));
+        assertEquals("C", dfsVisited.get(2));
+
+        List<String> bfsVisited = new ArrayList<>();
+        g5.breadthFirstTraversal(100, ctx -> bfsVisited.add(ctx.getLabel()));
+
+        assertEquals(3, bfsVisited.size());
+        assertEquals("A", bfsVisited.get(0));
+        assertEquals("B", bfsVisited.get(1));
+        assertEquals("C", bfsVisited.get(2));
+    }
+
+    @Test
+    @DisplayName("Adding duplicate node ID should throw exception")
+    void testAddDuplicateNodeIdThrowsException() {
+        ImmutableGraph<String, Integer> g0 = new ImmutableGraph<>();
+        ImmutableGraph<String, Integer> g1 = g0.addNodeWithId(42, "A");
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            g1.addNodeWithId(42, "B");
+        });
+    }
+
     /**
      * Build a test graph:
      *     A -> B -> D

--- a/src/test/java/com/robsartin/graphs/models/GraphTest.java
+++ b/src/test/java/com/robsartin/graphs/models/GraphTest.java
@@ -1,0 +1,163 @@
+package com.robsartin.graphs.models;
+
+import com.robsartin.graphs.config.TestOpenFeatureConfiguration;
+import com.robsartin.graphs.ports.out.GraphRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Import(TestOpenFeatureConfiguration.class)
+class GraphTest {
+
+    @Autowired
+    private GraphRepository graphRepository;
+
+    @BeforeEach
+    void setUp() {
+        graphRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("Node database ID should be used as immutable graph node ID")
+    void nodeDatabaseIdShouldBeUsedAsImmutableGraphNodeId() {
+        Graph graph = new Graph("Test Graph");
+        GraphNode node = graph.addNode("Node A");
+        Graph savedGraph = graphRepository.save(graph);
+
+        GraphNode savedNode = savedGraph.getNodes().get(0);
+        Integer nodeDbId = savedNode.getId();
+
+        // The immutable graph should contain a node with the same ID as the database ID
+        assertTrue(savedGraph.getImmutableGraph().containsNode(nodeDbId));
+        assertEquals("Node A", savedGraph.getImmutableGraph().getContext(nodeDbId).getLabel());
+    }
+
+    @Test
+    @DisplayName("Multiple nodes should use their database IDs in immutable graph")
+    void multipleNodesShouldUseDatabaseIdsInImmutableGraph() {
+        Graph graph = new Graph("Test Graph");
+        graph.addNode("Node A");
+        graph.addNode("Node B");
+        graph.addNode("Node C");
+        Graph savedGraph = graphRepository.save(graph);
+
+        for (GraphNode node : savedGraph.getNodes()) {
+            Integer nodeDbId = node.getId();
+            assertTrue(savedGraph.getImmutableGraph().containsNode(nodeDbId),
+                    "Immutable graph should contain node with database ID " + nodeDbId);
+            assertEquals(node.getName(), savedGraph.getImmutableGraph().getContext(nodeDbId).getLabel());
+        }
+    }
+
+    @Test
+    @DisplayName("Edges should work with database IDs")
+    void edgesShouldWorkWithDatabaseIds() {
+        Graph graph = new Graph("Test Graph");
+        graph.addNode("Node A");
+        graph.addNode("Node B");
+        Graph savedGraph = graphRepository.save(graph);
+
+        GraphNode nodeA = savedGraph.getNodes().stream()
+                .filter(n -> n.getName().equals("Node A"))
+                .findFirst().orElseThrow();
+        GraphNode nodeB = savedGraph.getNodes().stream()
+                .filter(n -> n.getName().equals("Node B"))
+                .findFirst().orElseThrow();
+
+        savedGraph.addEdge(nodeA.getId(), nodeB.getId());
+        Graph graphWithEdge = graphRepository.save(savedGraph);
+
+        var contextA = graphWithEdge.getImmutableGraph().getContext(nodeA.getId());
+        assertTrue(contextA.getSuccessors().containsKey(nodeB.getId()),
+                "Node A should have an edge to Node B using database IDs");
+    }
+
+    @Test
+    @DisplayName("findNodeById should find node by database ID")
+    void findNodeByIdShouldFindNodeByDatabaseId() {
+        Graph graph = new Graph("Test Graph");
+        graph.addNode("Node A");
+        graph.addNode("Node B");
+        Graph savedGraph = graphRepository.save(graph);
+
+        GraphNode nodeA = savedGraph.getNodes().stream()
+                .filter(n -> n.getName().equals("Node A"))
+                .findFirst().orElseThrow();
+
+        GraphNode found = savedGraph.findNodeById(nodeA.getId());
+        assertNotNull(found);
+        assertEquals("Node A", found.getName());
+    }
+
+    @Test
+    @DisplayName("Traversals should work with database IDs")
+    void traversalsShouldWorkWithDatabaseIds() {
+        Graph graph = new Graph("Test Graph");
+        graph.addNode("Node A");
+        graph.addNode("Node B");
+        graph.addNode("Node C");
+        Graph savedGraph = graphRepository.save(graph);
+
+        GraphNode nodeA = savedGraph.getNodes().stream()
+                .filter(n -> n.getName().equals("Node A"))
+                .findFirst().orElseThrow();
+        GraphNode nodeB = savedGraph.getNodes().stream()
+                .filter(n -> n.getName().equals("Node B"))
+                .findFirst().orElseThrow();
+        GraphNode nodeC = savedGraph.getNodes().stream()
+                .filter(n -> n.getName().equals("Node C"))
+                .findFirst().orElseThrow();
+
+        savedGraph.addEdge(nodeA.getId(), nodeB.getId());
+        savedGraph.addEdge(nodeB.getId(), nodeC.getId());
+        Graph graphWithEdges = graphRepository.save(savedGraph);
+
+        // DFS from Node A should visit A -> B -> C
+        java.util.List<String> dfsOrder = new java.util.ArrayList<>();
+        graphWithEdges.getImmutableGraph().depthFirstTraversal(nodeA.getId(),
+                ctx -> dfsOrder.add(ctx.getLabel()));
+
+        assertEquals(3, dfsOrder.size());
+        assertEquals("Node A", dfsOrder.get(0));
+        assertEquals("Node B", dfsOrder.get(1));
+        assertEquals("Node C", dfsOrder.get(2));
+    }
+
+    @Test
+    @DisplayName("Graph reconstruction on load should use database IDs")
+    void graphReconstructionOnLoadShouldUseDatabaseIds() {
+        // Create and save a graph with nodes
+        Graph graph = new Graph("Test Graph");
+        graph.addNode("Node A");
+        graph.addNode("Node B");
+        Graph savedGraph = graphRepository.save(graph);
+
+        Integer graphId = savedGraph.getId();
+        Integer nodeADbId = savedGraph.getNodes().stream()
+                .filter(n -> n.getName().equals("Node A"))
+                .findFirst().orElseThrow().getId();
+        Integer nodeBDbId = savedGraph.getNodes().stream()
+                .filter(n -> n.getName().equals("Node B"))
+                .findFirst().orElseThrow().getId();
+
+        // Clear entity manager to force reload
+        graphRepository.flush();
+
+        // Reload the graph - this should trigger @PostLoad
+        Graph reloadedGraph = graphRepository.findById(graphId).orElseThrow();
+
+        // Verify the immutable graph uses database IDs
+        assertTrue(reloadedGraph.getImmutableGraph().containsNode(nodeADbId));
+        assertTrue(reloadedGraph.getImmutableGraph().containsNode(nodeBDbId));
+        assertEquals("Node A", reloadedGraph.getImmutableGraph().getContext(nodeADbId).getLabel());
+        assertEquals("Node B", reloadedGraph.getImmutableGraph().getContext(nodeBDbId).getLabel());
+    }
+}


### PR DESCRIPTION
This change merges the separate graphNodeId field with the database ID (id), simplifying the API and eliminating the need for two different identifier systems.

Changes:
- Remove graphNodeId field from GraphNode entity
- Add ImmutableGraph.addNodeWithId() method for external ID assignment
- Update Graph to sync ImmutableGraph with database IDs after persistence
- Replace findNodeByGraphNodeId() with findNodeById() using database IDs
- Update GraphController to use database IDs for edges and traversals
- Change NodeInfoResponse to use 'id' instead of 'graphNodeId'
- Update all tests to use the new unified ID approach
- Add new tests for external node ID support in ImmutableGraph
- Add GraphTest for Graph model with unified ID verification

All API endpoints now use database IDs consistently:
- POST /graphs/{id}/nodes/{fromId}/{toId} - uses database node IDs
- GET /graphs/{id}/dfs/{nodeId} - uses database node ID
- GET /graphs/{id}/bfs/{nodeId} - uses database node ID
- GET /graphs/{id}/nodes/{nodeId} - response uses 'id' field