### PR TITLE
feat: add ImmutableGraph save/load controller with full graph persist…

### DIFF
--- a/src/main/java/com/robsartin/graphs/application/ImmutableGraphController.java
+++ b/src/main/java/com/robsartin/graphs/application/ImmutableGraphController.java
@@ -1,0 +1,278 @@
+package com.robsartin.graphs.application;
+
+import com.robsartin.graphs.models.ImmutableGraphEdgeEntity;
+import com.robsartin.graphs.models.ImmutableGraphEntity;
+import com.robsartin.graphs.models.ImmutableGraphNodeEntity;
+import com.robsartin.graphs.ports.out.ImmutableGraphRepository;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
+import io.micrometer.core.annotation.Timed;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * REST Controller for managing immutable graphs as a whole.
+ * Handles HTTP requests for saving and loading entire immutable graphs.
+ */
+@RestController
+@RequestMapping("/immutable-graphs")
+@Tag(name = "Immutable Graphs", description = "API for saving and loading entire immutable graphs")
+public class ImmutableGraphController {
+
+    private static final Logger log = LoggerFactory.getLogger(ImmutableGraphController.class);
+
+    private final ImmutableGraphRepository immutableGraphRepository;
+
+    public ImmutableGraphController(ImmutableGraphRepository immutableGraphRepository) {
+        this.immutableGraphRepository = immutableGraphRepository;
+    }
+
+    /**
+     * POST /immutable-graphs - Saves an entire immutable graph
+     *
+     * @param request the graph to save with all nodes and edges
+     * @return the saved graph with HTTP 201 status
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Save entire immutable graph", description = "Saves an entire immutable graph with all nodes and edges in a single operation")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Graph saved successfully",
+                    content = @Content(schema = @Schema(implementation = ImmutableGraphResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Invalid request - name is required", content = @Content)
+    })
+    @Timed(value = "immutableGraph.save", description = "Time taken to save an immutable graph")
+    @CircuitBreaker(name = "immutableGraphService")
+    @RateLimiter(name = "immutableGraphService")
+    @Retry(name = "immutableGraphService")
+    public ImmutableGraphResponse saveGraph(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "Immutable graph to save",
+                    required = true,
+                    content = @Content(schema = @Schema(implementation = SaveImmutableGraphRequest.class)))
+            @Valid @RequestBody SaveImmutableGraphRequest request) {
+
+        log.info("Saving immutable graph with name: {}, nodes: {}, edges: {}",
+                request.name(), request.nodes().size(), request.edges().size());
+
+        ImmutableGraphEntity graph = new ImmutableGraphEntity(request.name());
+
+        for (NodeRequest nodeRequest : request.nodes()) {
+            ImmutableGraphNodeEntity node = new ImmutableGraphNodeEntity(
+                    nodeRequest.graphNodeId(),
+                    nodeRequest.label()
+            );
+            graph.addNode(node);
+        }
+
+        for (EdgeRequest edgeRequest : request.edges()) {
+            ImmutableGraphEdgeEntity edge = new ImmutableGraphEdgeEntity(
+                    edgeRequest.fromId(),
+                    edgeRequest.toId()
+            );
+            graph.addEdge(edge);
+        }
+
+        ImmutableGraphEntity savedGraph = immutableGraphRepository.save(graph);
+
+        log.info("Saved immutable graph with graphId: {}", savedGraph.getGraphId());
+
+        return toResponse(savedGraph);
+    }
+
+    /**
+     * GET /immutable-graphs/{graphId} - Retrieves an entire immutable graph
+     *
+     * @param graphId the graph ID
+     * @return the graph with all nodes and edges if found, 404 if not found
+     */
+    @GetMapping("/{graphId}")
+    @Operation(summary = "Get entire immutable graph", description = "Retrieves an entire immutable graph with all nodes and edges")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Graph found",
+                    content = @Content(schema = @Schema(implementation = ImmutableGraphResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Graph not found", content = @Content)
+    })
+    @Timed(value = "immutableGraph.getById", description = "Time taken to retrieve an immutable graph by ID")
+    @CircuitBreaker(name = "immutableGraphService")
+    @RateLimiter(name = "immutableGraphService")
+    @Retry(name = "immutableGraphService")
+    public ResponseEntity<ImmutableGraphResponse> getGraph(
+            @Parameter(description = "Graph ID", required = true) @PathVariable Integer graphId) {
+
+        log.info("Retrieving immutable graph with graphId: {}", graphId);
+
+        return immutableGraphRepository.findById(graphId)
+                .map(graph -> {
+                    log.info("Found immutable graph: {}", graph.getName());
+                    return ResponseEntity.ok(toResponse(graph));
+                })
+                .orElseGet(() -> {
+                    log.warn("Immutable graph not found with graphId: {}", graphId);
+                    return ResponseEntity.notFound().build();
+                });
+    }
+
+    /**
+     * GET /immutable-graphs - Retrieves all immutable graphs
+     *
+     * @return list of all graphs with their nodes and edges
+     */
+    @GetMapping
+    @Operation(summary = "Get all immutable graphs", description = "Retrieves a list of all immutable graphs with their nodes and edges")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved list of graphs",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = ImmutableGraphResponse.class))))
+    })
+    @Timed(value = "immutableGraph.getAll", description = "Time taken to retrieve all immutable graphs")
+    @CircuitBreaker(name = "immutableGraphService")
+    @RateLimiter(name = "immutableGraphService")
+    @Retry(name = "immutableGraphService")
+    public List<ImmutableGraphResponse> getAllGraphs() {
+        log.info("Retrieving all immutable graphs");
+
+        List<ImmutableGraphResponse> graphs = immutableGraphRepository.findAll().stream()
+                .map(this::toResponse)
+                .toList();
+
+        log.info("Found {} immutable graphs", graphs.size());
+
+        return graphs;
+    }
+
+    /**
+     * DELETE /immutable-graphs/{graphId} - Deletes an immutable graph
+     *
+     * @param graphId the graph ID to delete
+     * @return 204 No Content if deleted, 404 if not found
+     */
+    @DeleteMapping("/{graphId}")
+    @Operation(summary = "Delete an immutable graph", description = "Deletes an immutable graph by its ID")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Graph deleted successfully"),
+            @ApiResponse(responseCode = "404", description = "Graph not found")
+    })
+    @Timed(value = "immutableGraph.delete", description = "Time taken to delete an immutable graph")
+    @CircuitBreaker(name = "immutableGraphService")
+    @RateLimiter(name = "immutableGraphService")
+    @Retry(name = "immutableGraphService")
+    public ResponseEntity<Void> deleteGraph(
+            @Parameter(description = "Graph ID to delete", required = true) @PathVariable Integer graphId) {
+
+        log.info("Deleting immutable graph with graphId: {}", graphId);
+
+        if (!immutableGraphRepository.existsById(graphId)) {
+            log.warn("Immutable graph not found for deletion with graphId: {}", graphId);
+            return ResponseEntity.notFound().build();
+        }
+
+        immutableGraphRepository.deleteById(graphId);
+
+        log.info("Deleted immutable graph with graphId: {}", graphId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    private ImmutableGraphResponse toResponse(ImmutableGraphEntity graph) {
+        List<NodeResponse> nodes = graph.getNodes().stream()
+                .sorted(Comparator.comparing(ImmutableGraphNodeEntity::getGraphNodeId))
+                .map(n -> new NodeResponse(n.getGraphNodeId(), n.getLabel()))
+                .toList();
+
+        List<EdgeResponse> edges = graph.getEdges().stream()
+                .map(e -> new EdgeResponse(e.getFromId(), e.getToId()))
+                .toList();
+
+        return new ImmutableGraphResponse(graph.getGraphId(), graph.getName(), nodes, edges);
+    }
+
+    /**
+     * Request DTO for saving an immutable graph
+     */
+    @Schema(description = "Request body for saving an immutable graph")
+    public record SaveImmutableGraphRequest(
+            @Schema(description = "Name of the graph", example = "My Graph", requiredMode = Schema.RequiredMode.REQUIRED)
+            @NotBlank(message = "Name is required") String name,
+            @Schema(description = "List of nodes in the graph")
+            @NotNull List<NodeRequest> nodes,
+            @Schema(description = "List of edges in the graph")
+            @NotNull List<EdgeRequest> edges) {
+    }
+
+    /**
+     * Request DTO for a node
+     */
+    @Schema(description = "Node information for saving")
+    public record NodeRequest(
+            @Schema(description = "Unique node ID within the graph", example = "0")
+            @NotNull Integer graphNodeId,
+            @Schema(description = "Label of the node", example = "Node A")
+            @NotBlank String label) {
+    }
+
+    /**
+     * Request DTO for an edge
+     */
+    @Schema(description = "Edge information for saving")
+    public record EdgeRequest(
+            @Schema(description = "Source node ID", example = "0")
+            @NotNull Integer fromId,
+            @Schema(description = "Target node ID", example = "1")
+            @NotNull Integer toId) {
+    }
+
+    /**
+     * Response DTO for an immutable graph
+     */
+    @Schema(description = "Response containing an immutable graph with all nodes and edges")
+    public record ImmutableGraphResponse(
+            @Schema(description = "Unique identifier of the graph", example = "1")
+            Integer graphId,
+            @Schema(description = "Name of the graph", example = "My Graph")
+            String name,
+            @Schema(description = "List of nodes in the graph")
+            List<NodeResponse> nodes,
+            @Schema(description = "List of edges in the graph")
+            List<EdgeResponse> edges) {
+    }
+
+    /**
+     * Response DTO for a node
+     */
+    @Schema(description = "Node information in response")
+    public record NodeResponse(
+            @Schema(description = "Unique node ID within the graph", example = "0")
+            Integer graphNodeId,
+            @Schema(description = "Label of the node", example = "Node A")
+            String label) {
+    }
+
+    /**
+     * Response DTO for an edge
+     */
+    @Schema(description = "Edge information in response")
+    public record EdgeResponse(
+            @Schema(description = "Source node ID", example = "0")
+            Integer fromId,
+            @Schema(description = "Target node ID", example = "1")
+            Integer toId) {
+    }
+}

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/ImmutableGraphRepositoryAdapter.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/ImmutableGraphRepositoryAdapter.java
@@ -1,0 +1,52 @@
+package com.robsartin.graphs.infrastructure.adapters.persistence;
+
+import com.robsartin.graphs.models.ImmutableGraphEntity;
+import com.robsartin.graphs.ports.out.ImmutableGraphRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Adapter that implements the ImmutableGraphRepository port using Spring Data JPA.
+ * This adapter translates between the domain port interface and the JPA repository.
+ */
+@Component
+public class ImmutableGraphRepositoryAdapter implements ImmutableGraphRepository {
+
+    private final JpaImmutableGraphRepository jpaImmutableGraphRepository;
+
+    public ImmutableGraphRepositoryAdapter(JpaImmutableGraphRepository jpaImmutableGraphRepository) {
+        this.jpaImmutableGraphRepository = jpaImmutableGraphRepository;
+    }
+
+    @Override
+    public ImmutableGraphEntity save(ImmutableGraphEntity graph) {
+        return jpaImmutableGraphRepository.save(graph);
+    }
+
+    @Override
+    public Optional<ImmutableGraphEntity> findById(Integer graphId) {
+        return jpaImmutableGraphRepository.findById(graphId);
+    }
+
+    @Override
+    public List<ImmutableGraphEntity> findAll() {
+        return jpaImmutableGraphRepository.findAll();
+    }
+
+    @Override
+    public void deleteById(Integer graphId) {
+        jpaImmutableGraphRepository.deleteById(graphId);
+    }
+
+    @Override
+    public boolean existsById(Integer graphId) {
+        return jpaImmutableGraphRepository.existsById(graphId);
+    }
+
+    @Override
+    public void deleteAll() {
+        jpaImmutableGraphRepository.deleteAll();
+    }
+}

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/JpaImmutableGraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/JpaImmutableGraphRepository.java
@@ -1,0 +1,9 @@
+package com.robsartin.graphs.infrastructure.adapters.persistence;
+
+import com.robsartin.graphs.models.ImmutableGraphEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface JpaImmutableGraphRepository extends JpaRepository<ImmutableGraphEntity, Integer> {
+}

--- a/src/main/java/com/robsartin/graphs/models/ImmutableGraphEdgeEntity.java
+++ b/src/main/java/com/robsartin/graphs/models/ImmutableGraphEdgeEntity.java
@@ -1,0 +1,95 @@
+package com.robsartin.graphs.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import java.util.Objects;
+
+/**
+ * Entity representing an edge in an immutable graph.
+ * The edge connects two nodes identified by fromId and toId.
+ */
+@Entity
+@Table(name = "immutable_graph_edges")
+public class ImmutableGraphEdgeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private Integer fromId;
+
+    private Integer toId;
+
+    @ManyToOne
+    @JoinColumn(name = "graph_id")
+    private ImmutableGraphEntity graph;
+
+    protected ImmutableGraphEdgeEntity() {
+        // JPA requires a no-arg constructor
+    }
+
+    public ImmutableGraphEdgeEntity(Integer fromId, Integer toId) {
+        this.fromId = fromId;
+        this.toId = toId;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getFromId() {
+        return fromId;
+    }
+
+    public void setFromId(Integer fromId) {
+        this.fromId = fromId;
+    }
+
+    public Integer getToId() {
+        return toId;
+    }
+
+    public void setToId(Integer toId) {
+        this.toId = toId;
+    }
+
+    public ImmutableGraphEntity getGraph() {
+        return graph;
+    }
+
+    public void setGraph(ImmutableGraphEntity graph) {
+        this.graph = graph;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableGraphEdgeEntity that = (ImmutableGraphEdgeEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableGraphEdgeEntity{" +
+                "id=" + id +
+                ", fromId=" + fromId +
+                ", toId=" + toId +
+                '}';
+    }
+}

--- a/src/main/java/com/robsartin/graphs/models/ImmutableGraphEntity.java
+++ b/src/main/java/com/robsartin/graphs/models/ImmutableGraphEntity.java
@@ -1,0 +1,107 @@
+package com.robsartin.graphs.models;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Entity representing an immutable graph that can be saved and loaded as a whole.
+ * The graph is identified by its graphId and contains nodes and edges.
+ */
+@Entity
+@Table(name = "immutable_graphs")
+public class ImmutableGraphEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer graphId;
+
+    private String name;
+
+    @OneToMany(mappedBy = "graph", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ImmutableGraphNodeEntity> nodes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "graph", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ImmutableGraphEdgeEntity> edges = new ArrayList<>();
+
+    protected ImmutableGraphEntity() {
+        // JPA requires a no-arg constructor
+    }
+
+    public ImmutableGraphEntity(String name) {
+        this.name = name;
+    }
+
+    public Integer getGraphId() {
+        return graphId;
+    }
+
+    public void setGraphId(Integer graphId) {
+        this.graphId = graphId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<ImmutableGraphNodeEntity> getNodes() {
+        return nodes;
+    }
+
+    public void setNodes(List<ImmutableGraphNodeEntity> nodes) {
+        this.nodes = nodes;
+    }
+
+    public List<ImmutableGraphEdgeEntity> getEdges() {
+        return edges;
+    }
+
+    public void setEdges(List<ImmutableGraphEdgeEntity> edges) {
+        this.edges = edges;
+    }
+
+    public void addNode(ImmutableGraphNodeEntity node) {
+        nodes.add(node);
+        node.setGraph(this);
+    }
+
+    public void addEdge(ImmutableGraphEdgeEntity edge) {
+        edges.add(edge);
+        edge.setGraph(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableGraphEntity that = (ImmutableGraphEntity) o;
+        return Objects.equals(graphId, that.graphId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(graphId);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableGraphEntity{" +
+                "graphId=" + graphId +
+                ", name='" + name + '\'' +
+                ", nodeCount=" + nodes.size() +
+                ", edgeCount=" + edges.size() +
+                '}';
+    }
+}

--- a/src/main/java/com/robsartin/graphs/models/ImmutableGraphNodeEntity.java
+++ b/src/main/java/com/robsartin/graphs/models/ImmutableGraphNodeEntity.java
@@ -1,0 +1,97 @@
+package com.robsartin.graphs.models;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import java.util.Objects;
+
+/**
+ * Entity representing a node in an immutable graph.
+ * The node is identified by the combination of graphId and graphNodeId.
+ */
+@Entity
+@Table(name = "immutable_graph_nodes",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"graph_id", "graphNodeId"}))
+public class ImmutableGraphNodeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private Integer graphNodeId;
+
+    private String label;
+
+    @ManyToOne
+    @JoinColumn(name = "graph_id")
+    private ImmutableGraphEntity graph;
+
+    protected ImmutableGraphNodeEntity() {
+        // JPA requires a no-arg constructor
+    }
+
+    public ImmutableGraphNodeEntity(Integer graphNodeId, String label) {
+        this.graphNodeId = graphNodeId;
+        this.label = label;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getGraphNodeId() {
+        return graphNodeId;
+    }
+
+    public void setGraphNodeId(Integer graphNodeId) {
+        this.graphNodeId = graphNodeId;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public ImmutableGraphEntity getGraph() {
+        return graph;
+    }
+
+    public void setGraph(ImmutableGraphEntity graph) {
+        this.graph = graph;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImmutableGraphNodeEntity that = (ImmutableGraphNodeEntity) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return "ImmutableGraphNodeEntity{" +
+                "id=" + id +
+                ", graphNodeId=" + graphNodeId +
+                ", label='" + label + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/robsartin/graphs/ports/out/ImmutableGraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/ports/out/ImmutableGraphRepository.java
@@ -1,0 +1,57 @@
+package com.robsartin.graphs.ports.out;
+
+import com.robsartin.graphs.models.ImmutableGraphEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Port for ImmutableGraph persistence operations.
+ * This interface defines the contract for storing and retrieving immutable graphs,
+ * independent of the actual persistence mechanism.
+ */
+public interface ImmutableGraphRepository {
+
+    /**
+     * Saves an immutable graph to the repository.
+     *
+     * @param graph the graph to save
+     * @return the saved graph with generated ID
+     */
+    ImmutableGraphEntity save(ImmutableGraphEntity graph);
+
+    /**
+     * Finds an immutable graph by its ID.
+     *
+     * @param graphId the graph ID
+     * @return an Optional containing the graph if found, or empty if not found
+     */
+    Optional<ImmutableGraphEntity> findById(Integer graphId);
+
+    /**
+     * Retrieves all immutable graphs from the repository.
+     *
+     * @return a list of all graphs
+     */
+    List<ImmutableGraphEntity> findAll();
+
+    /**
+     * Deletes an immutable graph by its ID.
+     *
+     * @param graphId the graph ID to delete
+     */
+    void deleteById(Integer graphId);
+
+    /**
+     * Checks if an immutable graph exists with the given ID.
+     *
+     * @param graphId the graph ID
+     * @return true if a graph exists, false otherwise
+     */
+    boolean existsById(Integer graphId);
+
+    /**
+     * Deletes all immutable graphs from the repository.
+     */
+    void deleteAll();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -99,6 +99,8 @@ resilience4j:
         base-config: default
       traversalService:
         base-config: default
+      immutableGraphService:
+        base-config: default
 
   retry:
     configs:
@@ -117,6 +119,8 @@ resilience4j:
         base-config: default
       traversalService:
         base-config: default
+      immutableGraphService:
+        base-config: default
 
   ratelimiter:
     configs:
@@ -132,6 +136,8 @@ resilience4j:
         base-config: default
       traversalService:
         base-config: default
+      immutableGraphService:
+        base-config: default
 
   timelimiter:
     configs:
@@ -144,4 +150,6 @@ resilience4j:
       nodeService:
         base-config: default
       traversalService:
+        base-config: default
+      immutableGraphService:
         base-config: default

--- a/src/test/java/com/robsartin/graphs/application/ImmutableGraphControllerTest.java
+++ b/src/test/java/com/robsartin/graphs/application/ImmutableGraphControllerTest.java
@@ -1,0 +1,431 @@
+package com.robsartin.graphs.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.robsartin.graphs.config.TestOpenFeatureConfiguration;
+import com.robsartin.graphs.models.ImmutableGraphEntity;
+import com.robsartin.graphs.models.ImmutableGraphNodeEntity;
+import com.robsartin.graphs.models.ImmutableGraphEdgeEntity;
+import com.robsartin.graphs.ports.out.ImmutableGraphRepository;
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestOpenFeatureConfiguration.class)
+class ImmutableGraphControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ImmutableGraphRepository immutableGraphRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        immutableGraphRepository.deleteAll();
+    }
+
+    // POST /immutable-graphs - save entire immutable graph
+    @Test
+    void shouldSaveEntireImmutableGraph() throws Exception {
+        String requestBody = """
+            {
+                "name": "Test Graph",
+                "nodes": [
+                    {"graphNodeId": 0, "label": "Node A"},
+                    {"graphNodeId": 1, "label": "Node B"},
+                    {"graphNodeId": 2, "label": "Node C"}
+                ],
+                "edges": [
+                    {"fromId": 0, "toId": 1},
+                    {"fromId": 1, "toId": 2}
+                ]
+            }
+            """;
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.graphId").exists())
+                .andExpect(jsonPath("$.name").value("Test Graph"))
+                .andExpect(jsonPath("$.nodes").isArray())
+                .andExpect(jsonPath("$.nodes.length()").value(3))
+                .andExpect(jsonPath("$.edges").isArray())
+                .andExpect(jsonPath("$.edges.length()").value(2));
+    }
+
+    @Test
+    void shouldSaveEmptyGraph() throws Exception {
+        String requestBody = """
+            {
+                "name": "Empty Graph",
+                "nodes": [],
+                "edges": []
+            }
+            """;
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.graphId").exists())
+                .andExpect(jsonPath("$.name").value("Empty Graph"))
+                .andExpect(jsonPath("$.nodes").isArray())
+                .andExpect(jsonPath("$.nodes.length()").value(0))
+                .andExpect(jsonPath("$.edges").isArray())
+                .andExpect(jsonPath("$.edges.length()").value(0));
+    }
+
+    @Test
+    void shouldSaveGraphWithNodesButNoEdges() throws Exception {
+        String requestBody = """
+            {
+                "name": "Disconnected Graph",
+                "nodes": [
+                    {"graphNodeId": 0, "label": "Node A"},
+                    {"graphNodeId": 1, "label": "Node B"}
+                ],
+                "edges": []
+            }
+            """;
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.graphId").exists())
+                .andExpect(jsonPath("$.name").value("Disconnected Graph"))
+                .andExpect(jsonPath("$.nodes.length()").value(2))
+                .andExpect(jsonPath("$.edges.length()").value(0));
+    }
+
+    @Test
+    void shouldRejectGraphWithoutName() throws Exception {
+        String requestBody = """
+            {
+                "nodes": [],
+                "edges": []
+            }
+            """;
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldRejectGraphWithEmptyName() throws Exception {
+        String requestBody = """
+            {
+                "name": "",
+                "nodes": [],
+                "edges": []
+            }
+            """;
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldRejectGraphWithBlankName() throws Exception {
+        String requestBody = """
+            {
+                "name": "   ",
+                "nodes": [],
+                "edges": []
+            }
+            """;
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldPersistGraphWhenSaving() throws Exception {
+        String requestBody = """
+            {
+                "name": "Test Graph",
+                "nodes": [
+                    {"graphNodeId": 0, "label": "Node A"}
+                ],
+                "edges": []
+            }
+            """;
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+
+        List<ImmutableGraphEntity> graphs = immutableGraphRepository.findAll();
+        assert graphs.size() == 1;
+        assert graphs.get(0).getName().equals("Test Graph");
+        assert graphs.get(0).getNodes().size() == 1;
+    }
+
+    // GET /immutable-graphs/{graphId} - get entire immutable graph
+    @Test
+    void shouldReturnEntireImmutableGraph() throws Exception {
+        // First save a graph
+        String requestBody = """
+            {
+                "name": "Test Graph",
+                "nodes": [
+                    {"graphNodeId": 0, "label": "Node A"},
+                    {"graphNodeId": 1, "label": "Node B"},
+                    {"graphNodeId": 2, "label": "Node C"}
+                ],
+                "edges": [
+                    {"fromId": 0, "toId": 1},
+                    {"fromId": 1, "toId": 2}
+                ]
+            }
+            """;
+
+        String response = mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Integer graphId = objectMapper.readTree(response).get("graphId").asInt();
+
+        // Clear persistence context to simulate separate HTTP request
+        entityManager.flush();
+        entityManager.clear();
+
+        // Now retrieve the graph
+        mockMvc.perform(get("/immutable-graphs/" + graphId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.graphId").value(graphId))
+                .andExpect(jsonPath("$.name").value("Test Graph"))
+                .andExpect(jsonPath("$.nodes").isArray())
+                .andExpect(jsonPath("$.nodes.length()").value(3))
+                .andExpect(jsonPath("$.nodes[0].graphNodeId").value(0))
+                .andExpect(jsonPath("$.nodes[0].label").value("Node A"))
+                .andExpect(jsonPath("$.nodes[1].graphNodeId").value(1))
+                .andExpect(jsonPath("$.nodes[1].label").value("Node B"))
+                .andExpect(jsonPath("$.nodes[2].graphNodeId").value(2))
+                .andExpect(jsonPath("$.nodes[2].label").value("Node C"))
+                .andExpect(jsonPath("$.edges").isArray())
+                .andExpect(jsonPath("$.edges.length()").value(2));
+    }
+
+    @Test
+    void shouldReturn404WhenGraphNotFound() throws Exception {
+        mockMvc.perform(get("/immutable-graphs/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturnEmptyGraphWhenNoNodesOrEdges() throws Exception {
+        // First save an empty graph
+        String requestBody = """
+            {
+                "name": "Empty Graph",
+                "nodes": [],
+                "edges": []
+            }
+            """;
+
+        String response = mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Integer graphId = objectMapper.readTree(response).get("graphId").asInt();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(get("/immutable-graphs/" + graphId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.graphId").value(graphId))
+                .andExpect(jsonPath("$.name").value("Empty Graph"))
+                .andExpect(jsonPath("$.nodes").isArray())
+                .andExpect(jsonPath("$.nodes.length()").value(0))
+                .andExpect(jsonPath("$.edges").isArray())
+                .andExpect(jsonPath("$.edges.length()").value(0));
+    }
+
+    // GET /immutable-graphs - list all immutable graphs
+    @Test
+    void shouldReturnAllImmutableGraphs() throws Exception {
+        String requestBody1 = """
+            {
+                "name": "Graph 1",
+                "nodes": [{"graphNodeId": 0, "label": "Node A"}],
+                "edges": []
+            }
+            """;
+
+        String requestBody2 = """
+            {
+                "name": "Graph 2",
+                "nodes": [{"graphNodeId": 0, "label": "Node B"}],
+                "edges": []
+            }
+            """;
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody1))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody2))
+                .andExpect(status().isCreated());
+
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(get("/immutable-graphs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].name").value("Graph 1"))
+                .andExpect(jsonPath("$[1].name").value("Graph 2"));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoGraphs() throws Exception {
+        mockMvc.perform(get("/immutable-graphs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+
+    // DELETE /immutable-graphs/{graphId} - delete immutable graph
+    @Test
+    void shouldDeleteImmutableGraph() throws Exception {
+        String requestBody = """
+            {
+                "name": "Test Graph",
+                "nodes": [{"graphNodeId": 0, "label": "Node A"}],
+                "edges": []
+            }
+            """;
+
+        String response = mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Integer graphId = objectMapper.readTree(response).get("graphId").asInt();
+
+        mockMvc.perform(delete("/immutable-graphs/" + graphId))
+                .andExpect(status().isNoContent());
+
+        assert immutableGraphRepository.findById(graphId).isEmpty();
+    }
+
+    @Test
+    void shouldReturn404WhenDeletingNonExistentGraph() throws Exception {
+        mockMvc.perform(delete("/immutable-graphs/999"))
+                .andExpect(status().isNotFound());
+    }
+
+    // Test edge relationships
+    @Test
+    void shouldPreserveEdgeRelationships() throws Exception {
+        String requestBody = """
+            {
+                "name": "Complex Graph",
+                "nodes": [
+                    {"graphNodeId": 0, "label": "A"},
+                    {"graphNodeId": 1, "label": "B"},
+                    {"graphNodeId": 2, "label": "C"},
+                    {"graphNodeId": 3, "label": "D"}
+                ],
+                "edges": [
+                    {"fromId": 0, "toId": 1},
+                    {"fromId": 0, "toId": 2},
+                    {"fromId": 1, "toId": 3},
+                    {"fromId": 2, "toId": 3}
+                ]
+            }
+            """;
+
+        String response = mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Integer graphId = objectMapper.readTree(response).get("graphId").asInt();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(get("/immutable-graphs/" + graphId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nodes.length()").value(4))
+                .andExpect(jsonPath("$.edges.length()").value(4));
+    }
+
+    // Test cyclic graph
+    @Test
+    void shouldSaveCyclicGraph() throws Exception {
+        String requestBody = """
+            {
+                "name": "Cyclic Graph",
+                "nodes": [
+                    {"graphNodeId": 0, "label": "A"},
+                    {"graphNodeId": 1, "label": "B"},
+                    {"graphNodeId": 2, "label": "C"}
+                ],
+                "edges": [
+                    {"fromId": 0, "toId": 1},
+                    {"fromId": 1, "toId": 2},
+                    {"fromId": 2, "toId": 0}
+                ]
+            }
+            """;
+
+        String response = mockMvc.perform(post("/immutable-graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        Integer graphId = objectMapper.readTree(response).get("graphId").asInt();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        mockMvc.perform(get("/immutable-graphs/" + graphId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.edges.length()").value(3));
+    }
+}


### PR DESCRIPTION
…ence

Add new REST endpoints for saving and loading entire immutable graphs:

- POST /immutable-graphs: Save entire graph with nodes and edges
- GET /immutable-graphs: List all immutable graphs
- GET /immutable-graphs/{graphId}: Retrieve entire graph by ID
- DELETE /immutable-graphs/{graphId}: Delete graph by ID

New models:
- ImmutableGraphEntity: Root entity with graphId primary key
- ImmutableGraphNodeEntity: Node with composite key (graphId, graphNodeId)
- ImmutableGraphEdgeEntity: Edge with fromId and toId references

Implementation follows hexagonal architecture patterns:
- Port interface in ports/out
- JPA repository and adapter in infrastructure/adapters/persistence
- Controller in application layer with resilience4j decorators
- Comprehensive integration tests following TDD approach