### PR TITLE
feat: unify nodeId and graphNodeId to UUID v7

### DIFF
--- a/src/main/java/com/robsartin/graphs/application/RandomGraphDemo.java
+++ b/src/main/java/com/robsartin/graphs/application/RandomGraphDemo.java
@@ -24,17 +24,20 @@ public class RandomGraphDemo {
         System.out.println("Graph created successfully!");
         System.out.println();
 
-        // Perform depth-first traversal starting from node 0 (labeled "1")
+        // Perform traversals using the first node
+        UUID startNode = graph.getNodeIds().iterator().next();
+
+        // Perform depth-first traversal starting from first node
         System.out.println("=== Depth-First Traversal ===");
-        graph.depthFirstTraversal(0, context -> {
+        graph.depthFirstTraversal(startNode, context -> {
             System.out.println(context.getLabel());
         });
 
         System.out.println();
 
-        // Perform breadth-first traversal starting from node 0 (labeled "1")
+        // Perform breadth-first traversal starting from first node
         System.out.println("=== Breadth-First Traversal ===");
-        graph.breadthFirstTraversal(0, context -> {
+        graph.breadthFirstTraversal(startNode, context -> {
             System.out.println(context.getLabel());
         });
     }
@@ -46,13 +49,13 @@ public class RandomGraphDemo {
      */
     private static ImmutableGraph<String, Integer> createRandomGraphWithPreferentialAttachment() {
         ImmutableGraph<String, Integer> graph = new ImmutableGraph<>();
-        int[] nodeIds = new int[NUM_NODES];
+        List<UUID> nodeIds = new ArrayList<>();
 
         // Create all nodes first (labeled "1" through "10")
         for (int i = 0; i < NUM_NODES; i++) {
             var result = graph.addNode(String.valueOf(i + 1));
             graph = result.getGraph();
-            nodeIds[i] = result.getNodeId();
+            nodeIds.add(result.getNodeId());
         }
 
         // Track degree of each node for preferential attachment
@@ -72,7 +75,7 @@ public class RandomGraphDemo {
 
             // Add the edge
             try {
-                graph = graph.addEdge(nodeIds[fromIndex], nodeIds[toIndex], edgeCount + 1);
+                graph = graph.addEdge(nodeIds.get(fromIndex), nodeIds.get(toIndex), edgeCount + 1);
                 degrees[fromIndex]++;
                 degrees[toIndex]++;
             } catch (Exception e) {

--- a/src/main/java/com/robsartin/graphs/infrastructure/UuidV7Generator.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/UuidV7Generator.java
@@ -1,0 +1,78 @@
+package com.robsartin.graphs.infrastructure;
+
+import java.security.SecureRandom;
+import java.util.UUID;
+
+/**
+ * Utility class for generating UUID v7 (time-ordered UUID).
+ * UUID v7 structure:
+ * - 48 bits: Unix timestamp in milliseconds
+ * - 4 bits: Version (7)
+ * - 12 bits: Random
+ * - 2 bits: Variant (10)
+ * - 62 bits: Random
+ */
+public final class UuidV7Generator {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private UuidV7Generator() {
+    }
+
+    /**
+     * Generates a UUID v7 (time-ordered UUID).
+     *
+     * @return a new UUID v7
+     */
+    public static UUID generate() {
+        long timestamp = System.currentTimeMillis();
+
+        // Generate random bytes for the random portion
+        byte[] randomBytes = new byte[10];
+        RANDOM.nextBytes(randomBytes);
+
+        // Build the most significant bits (48 bits timestamp + 4 bits version + 12 bits random)
+        long msb = (timestamp << 16) | (7L << 12) | ((randomBytes[0] & 0xFF) << 4) | ((randomBytes[1] & 0xF0) >> 4);
+
+        // Build the least significant bits (2 bits variant + 62 bits random)
+        long lsb = (2L << 62) // Variant bits (10)
+                | ((randomBytes[1] & 0x0FL) << 58)
+                | ((randomBytes[2] & 0xFFL) << 50)
+                | ((randomBytes[3] & 0xFFL) << 42)
+                | ((randomBytes[4] & 0xFFL) << 34)
+                | ((randomBytes[5] & 0xFFL) << 26)
+                | ((randomBytes[6] & 0xFFL) << 18)
+                | ((randomBytes[7] & 0xFFL) << 10)
+                | ((randomBytes[8] & 0xFFL) << 2)
+                | ((randomBytes[9] & 0xC0L) >> 6);
+
+        return new UUID(msb, lsb);
+    }
+
+    /**
+     * Generates a UUID v7 as a string.
+     *
+     * @return a new UUID v7 as a string
+     */
+    public static String generateString() {
+        return generate().toString();
+    }
+
+    /**
+     * Validates if a string is a valid UUID format.
+     *
+     * @param uuid the string to validate
+     * @return true if valid UUID format, false otherwise
+     */
+    public static boolean isValidUuid(String uuid) {
+        if (uuid == null || uuid.isBlank()) {
+            return false;
+        }
+        try {
+            UUID.fromString(uuid);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapter.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Adapter that implements the GraphRepository port using Spring Data JPA.
@@ -26,7 +27,7 @@ public class GraphRepositoryAdapter implements GraphRepository {
     }
 
     @Override
-    public Optional<Graph> findById(Integer id) {
+    public Optional<Graph> findById(UUID id) {
         return jpaGraphRepository.findById(id);
     }
 
@@ -36,12 +37,12 @@ public class GraphRepositoryAdapter implements GraphRepository {
     }
 
     @Override
-    public void deleteById(Integer id) {
+    public void deleteById(UUID id) {
         jpaGraphRepository.deleteById(id);
     }
 
     @Override
-    public boolean existsById(Integer id) {
+    public boolean existsById(UUID id) {
         return jpaGraphRepository.existsById(id);
     }
 

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/ImmutableGraphRepositoryAdapter.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/ImmutableGraphRepositoryAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Adapter that implements the ImmutableGraphRepository port using Spring Data JPA.
@@ -26,8 +27,8 @@ public class ImmutableGraphRepositoryAdapter implements ImmutableGraphRepository
     }
 
     @Override
-    public Optional<ImmutableGraphEntity> findById(Integer graphId) {
-        return jpaImmutableGraphRepository.findById(graphId);
+    public Optional<ImmutableGraphEntity> findById(UUID id) {
+        return jpaImmutableGraphRepository.findById(id);
     }
 
     @Override
@@ -36,13 +37,13 @@ public class ImmutableGraphRepositoryAdapter implements ImmutableGraphRepository
     }
 
     @Override
-    public void deleteById(Integer graphId) {
-        jpaImmutableGraphRepository.deleteById(graphId);
+    public void deleteById(UUID id) {
+        jpaImmutableGraphRepository.deleteById(id);
     }
 
     @Override
-    public boolean existsById(Integer graphId) {
-        return jpaImmutableGraphRepository.existsById(graphId);
+    public boolean existsById(UUID id) {
+        return jpaImmutableGraphRepository.existsById(id);
     }
 
     @Override

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/JpaGraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/JpaGraphRepository.java
@@ -4,6 +4,8 @@ import com.robsartin.graphs.models.Graph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
-public interface JpaGraphRepository extends JpaRepository<Graph, Integer> {
+public interface JpaGraphRepository extends JpaRepository<Graph, UUID> {
 }

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/JpaImmutableGraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/JpaImmutableGraphRepository.java
@@ -4,6 +4,8 @@ import com.robsartin.graphs.models.ImmutableGraphEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 @Repository
-public interface JpaImmutableGraphRepository extends JpaRepository<ImmutableGraphEntity, Integer> {
+public interface JpaImmutableGraphRepository extends JpaRepository<ImmutableGraphEntity, UUID> {
 }

--- a/src/main/java/com/robsartin/graphs/infrastructure/correlation/CorrelationIdContext.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/correlation/CorrelationIdContext.java
@@ -1,9 +1,7 @@
 package com.robsartin.graphs.infrastructure.correlation;
 
+import com.robsartin.graphs.infrastructure.UuidV7Generator;
 import org.slf4j.MDC;
-
-import java.security.SecureRandom;
-import java.util.UUID;
 
 /**
  * Holds the correlation ID for the current request context.
@@ -15,7 +13,6 @@ public final class CorrelationIdContext {
     public static final String CORRELATION_ID_MDC_KEY = "correlationId";
 
     private static final ThreadLocal<String> CORRELATION_ID = new ThreadLocal<>();
-    private static final SecureRandom RANDOM = new SecureRandom();
 
     private CorrelationIdContext() {
     }
@@ -48,39 +45,12 @@ public final class CorrelationIdContext {
     }
 
     /**
-     * Generates a UUID v7 (time-ordered UUID).
-     * UUID v7 structure:
-     * - 48 bits: Unix timestamp in milliseconds
-     * - 4 bits: Version (7)
-     * - 12 bits: Random
-     * - 2 bits: Variant (10)
-     * - 62 bits: Random
+     * Generates a UUID v7 (time-ordered UUID) as a correlation ID.
      *
      * @return a new UUID v7 as a string
      */
     public static String generateCorrelationId() {
-        long timestamp = System.currentTimeMillis();
-
-        // Generate random bytes for the random portion
-        byte[] randomBytes = new byte[10];
-        RANDOM.nextBytes(randomBytes);
-
-        // Build the most significant bits (48 bits timestamp + 4 bits version + 12 bits random)
-        long msb = (timestamp << 16) | (7L << 12) | ((randomBytes[0] & 0xFF) << 4) | ((randomBytes[1] & 0xF0) >> 4);
-
-        // Build the least significant bits (2 bits variant + 62 bits random)
-        long lsb = (2L << 62) // Variant bits (10)
-                | ((randomBytes[1] & 0x0FL) << 58)
-                | ((randomBytes[2] & 0xFFL) << 50)
-                | ((randomBytes[3] & 0xFFL) << 42)
-                | ((randomBytes[4] & 0xFFL) << 34)
-                | ((randomBytes[5] & 0xFFL) << 26)
-                | ((randomBytes[6] & 0xFFL) << 18)
-                | ((randomBytes[7] & 0xFFL) << 10)
-                | ((randomBytes[8] & 0xFFL) << 2)
-                | ((randomBytes[9] & 0xC0L) >> 6);
-
-        return new UUID(msb, lsb).toString();
+        return UuidV7Generator.generateString();
     }
 
     /**
@@ -90,14 +60,6 @@ public final class CorrelationIdContext {
      * @return true if valid UUID format, false otherwise
      */
     public static boolean isValidUuid(String uuid) {
-        if (uuid == null || uuid.isBlank()) {
-            return false;
-        }
-        try {
-            UUID.fromString(uuid);
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
+        return UuidV7Generator.isValidUuid(uuid);
     }
 }

--- a/src/main/java/com/robsartin/graphs/models/GraphNode.java
+++ b/src/main/java/com/robsartin/graphs/models/GraphNode.java
@@ -1,26 +1,24 @@
 package com.robsartin.graphs.models;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import java.util.Objects;
+import java.util.UUID;
 
 @Entity
 @Table(name = "graph_nodes")
 public class GraphNode {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    @Column(columnDefinition = "uuid")
+    private UUID id;
 
     private String name;
-
-    private Integer graphNodeId;
 
     @ManyToOne
     @JoinColumn(name = "graph_id")
@@ -30,20 +28,16 @@ public class GraphNode {
         // JPA requires a no-arg constructor
     }
 
-    public GraphNode(String name) {
+    public GraphNode(String name, UUID id) {
+        this.id = id;
         this.name = name;
     }
 
-    public GraphNode(String name, Integer graphNodeId) {
-        this.name = name;
-        this.graphNodeId = graphNodeId;
-    }
-
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 
@@ -53,14 +47,6 @@ public class GraphNode {
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public Integer getGraphNodeId() {
-        return graphNodeId;
-    }
-
-    public void setGraphNodeId(Integer graphNodeId) {
-        this.graphNodeId = graphNodeId;
     }
 
     public Graph getGraph() {
@@ -89,7 +75,6 @@ public class GraphNode {
         return "GraphNode{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
-                ", graphNodeId=" + graphNodeId +
                 '}';
     }
 }

--- a/src/main/java/com/robsartin/graphs/models/ImmutableGraphEdgeEntity.java
+++ b/src/main/java/com/robsartin/graphs/models/ImmutableGraphEdgeEntity.java
@@ -1,30 +1,34 @@
 package com.robsartin.graphs.models;
 
+import com.robsartin.graphs.infrastructure.UuidV7Generator;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * Entity representing an edge in an immutable graph.
- * The edge connects two nodes identified by fromId and toId.
+ * The edge connects two nodes identified by fromId and toId (which are node UUIDs).
  */
 @Entity
 @Table(name = "immutable_graph_edges")
 public class ImmutableGraphEdgeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
+    @Column(columnDefinition = "uuid")
+    private UUID id;
 
-    private Integer fromId;
+    @Column(columnDefinition = "uuid")
+    private UUID fromId;
 
-    private Integer toId;
+    @Column(columnDefinition = "uuid")
+    private UUID toId;
 
     @ManyToOne
     @JoinColumn(name = "graph_id")
@@ -34,32 +38,40 @@ public class ImmutableGraphEdgeEntity {
         // JPA requires a no-arg constructor
     }
 
-    public ImmutableGraphEdgeEntity(Integer fromId, Integer toId) {
+    public ImmutableGraphEdgeEntity(UUID fromId, UUID toId) {
+        this.id = UuidV7Generator.generate();
         this.fromId = fromId;
         this.toId = toId;
     }
 
-    public Integer getId() {
+    @PrePersist
+    private void ensureId() {
+        if (this.id == null) {
+            this.id = UuidV7Generator.generate();
+        }
+    }
+
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 
-    public Integer getFromId() {
+    public UUID getFromId() {
         return fromId;
     }
 
-    public void setFromId(Integer fromId) {
+    public void setFromId(UUID fromId) {
         this.fromId = fromId;
     }
 
-    public Integer getToId() {
+    public UUID getToId() {
         return toId;
     }
 
-    public void setToId(Integer toId) {
+    public void setToId(UUID toId) {
         this.toId = toId;
     }
 

--- a/src/main/java/com/robsartin/graphs/models/ImmutableGraphEntity.java
+++ b/src/main/java/com/robsartin/graphs/models/ImmutableGraphEntity.java
@@ -1,28 +1,30 @@
 package com.robsartin.graphs.models;
 
+import com.robsartin.graphs.infrastructure.UuidV7Generator;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * Entity representing an immutable graph that can be saved and loaded as a whole.
- * The graph is identified by its graphId and contains nodes and edges.
+ * The graph is identified by its UUID id and contains nodes and edges.
  */
 @Entity
 @Table(name = "immutable_graphs")
 public class ImmutableGraphEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer graphId;
+    @Column(columnDefinition = "uuid")
+    private UUID id;
 
     private String name;
 
@@ -37,15 +39,23 @@ public class ImmutableGraphEntity {
     }
 
     public ImmutableGraphEntity(String name) {
+        this.id = UuidV7Generator.generate();
         this.name = name;
     }
 
-    public Integer getGraphId() {
-        return graphId;
+    @PrePersist
+    private void ensureId() {
+        if (this.id == null) {
+            this.id = UuidV7Generator.generate();
+        }
     }
 
-    public void setGraphId(Integer graphId) {
-        this.graphId = graphId;
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
     }
 
     public String getName() {
@@ -87,18 +97,18 @@ public class ImmutableGraphEntity {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ImmutableGraphEntity that = (ImmutableGraphEntity) o;
-        return Objects.equals(graphId, that.graphId);
+        return Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(graphId);
+        return Objects.hash(id);
     }
 
     @Override
     public String toString() {
         return "ImmutableGraphEntity{" +
-                "graphId=" + graphId +
+                "id=" + id +
                 ", name='" + name + '\'' +
                 ", nodeCount=" + nodes.size() +
                 ", edgeCount=" + edges.size() +

--- a/src/main/java/com/robsartin/graphs/models/ImmutableGraphNodeEntity.java
+++ b/src/main/java/com/robsartin/graphs/models/ImmutableGraphNodeEntity.java
@@ -1,8 +1,7 @@
 package com.robsartin.graphs.models;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -10,21 +9,20 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * Entity representing a node in an immutable graph.
- * The node is identified by the combination of graphId and graphNodeId.
+ * The node is identified by its UUID which is the same as the ImmutableGraph nodeId.
  */
 @Entity
 @Table(name = "immutable_graph_nodes",
-       uniqueConstraints = @UniqueConstraint(columnNames = {"graph_id", "graphNodeId"}))
+       uniqueConstraints = @UniqueConstraint(columnNames = {"graph_id", "id"}))
 public class ImmutableGraphNodeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer id;
-
-    private Integer graphNodeId;
+    @Column(columnDefinition = "uuid")
+    private UUID id;
 
     private String label;
 
@@ -36,25 +34,17 @@ public class ImmutableGraphNodeEntity {
         // JPA requires a no-arg constructor
     }
 
-    public ImmutableGraphNodeEntity(Integer graphNodeId, String label) {
-        this.graphNodeId = graphNodeId;
+    public ImmutableGraphNodeEntity(UUID id, String label) {
+        this.id = id;
         this.label = label;
     }
 
-    public Integer getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(UUID id) {
         this.id = id;
-    }
-
-    public Integer getGraphNodeId() {
-        return graphNodeId;
-    }
-
-    public void setGraphNodeId(Integer graphNodeId) {
-        this.graphNodeId = graphNodeId;
     }
 
     public String getLabel() {
@@ -90,7 +80,6 @@ public class ImmutableGraphNodeEntity {
     public String toString() {
         return "ImmutableGraphNodeEntity{" +
                 "id=" + id +
-                ", graphNodeId=" + graphNodeId +
                 ", label='" + label + '\'' +
                 '}';
     }

--- a/src/main/java/com/robsartin/graphs/ports/out/GraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/ports/out/GraphRepository.java
@@ -4,6 +4,7 @@ import com.robsartin.graphs.models.Graph;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Port for Graph persistence operations.
@@ -26,7 +27,7 @@ public interface GraphRepository {
      * @param id the graph ID
      * @return an Optional containing the graph if found, or empty if not found
      */
-    Optional<Graph> findById(Integer id);
+    Optional<Graph> findById(UUID id);
 
     /**
      * Retrieves all graphs from the repository.
@@ -40,7 +41,7 @@ public interface GraphRepository {
      *
      * @param id the graph ID to delete
      */
-    void deleteById(Integer id);
+    void deleteById(UUID id);
 
     /**
      * Checks if a graph exists with the given ID.
@@ -48,7 +49,7 @@ public interface GraphRepository {
      * @param id the graph ID
      * @return true if a graph exists, false otherwise
      */
-    boolean existsById(Integer id);
+    boolean existsById(UUID id);
 
     /**
      * Deletes all graphs from the repository.

--- a/src/main/java/com/robsartin/graphs/ports/out/ImmutableGraphRepository.java
+++ b/src/main/java/com/robsartin/graphs/ports/out/ImmutableGraphRepository.java
@@ -4,6 +4,7 @@ import com.robsartin.graphs.models.ImmutableGraphEntity;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Port for ImmutableGraph persistence operations.
@@ -23,10 +24,10 @@ public interface ImmutableGraphRepository {
     /**
      * Finds an immutable graph by its ID.
      *
-     * @param graphId the graph ID
+     * @param id the graph ID
      * @return an Optional containing the graph if found, or empty if not found
      */
-    Optional<ImmutableGraphEntity> findById(Integer graphId);
+    Optional<ImmutableGraphEntity> findById(UUID id);
 
     /**
      * Retrieves all immutable graphs from the repository.
@@ -38,17 +39,17 @@ public interface ImmutableGraphRepository {
     /**
      * Deletes an immutable graph by its ID.
      *
-     * @param graphId the graph ID to delete
+     * @param id the graph ID to delete
      */
-    void deleteById(Integer graphId);
+    void deleteById(UUID id);
 
     /**
      * Checks if an immutable graph exists with the given ID.
      *
-     * @param graphId the graph ID
+     * @param id the graph ID
      * @return true if a graph exists, false otherwise
      */
-    boolean existsById(Integer graphId);
+    boolean existsById(UUID id);
 
     /**
      * Deletes all immutable graphs from the repository.

--- a/src/test/java/com/robsartin/graphs/application/GraphControllerTest.java
+++ b/src/test/java/com/robsartin/graphs/application/GraphControllerTest.java
@@ -2,6 +2,7 @@ package com.robsartin.graphs.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.robsartin.graphs.config.TestOpenFeatureConfiguration;
+import com.robsartin.graphs.infrastructure.UuidV7Generator;
 import com.robsartin.graphs.models.Graph;
 import com.robsartin.graphs.models.GraphNode;
 import com.robsartin.graphs.ports.out.GraphRepository;
@@ -16,6 +17,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -75,13 +78,14 @@ class GraphControllerTest {
 
         mockMvc.perform(get("/graphs/" + savedGraph.getId()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(savedGraph.getId()))
+                .andExpect(jsonPath("$.id").value(savedGraph.getId().toString()))
                 .andExpect(jsonPath("$.name").value("Test Graph"));
     }
 
     @Test
     void shouldReturn404WhenGraphNotFound() throws Exception {
-        mockMvc.perform(get("/graphs/999"))
+        UUID randomUuid = UuidV7Generator.generate();
+        mockMvc.perform(get("/graphs/" + randomUuid))
                 .andExpect(status().isNotFound());
     }
 
@@ -153,7 +157,8 @@ class GraphControllerTest {
 
     @Test
     void shouldReturn404WhenDeletingNonExistentGraph() throws Exception {
-        mockMvc.perform(delete("/graphs/999"))
+        UUID randomUuid = UuidV7Generator.generate();
+        mockMvc.perform(delete("/graphs/" + randomUuid))
                 .andExpect(status().isNotFound());
     }
 
@@ -161,9 +166,11 @@ class GraphControllerTest {
     @Test
     void shouldReturnAllNodesInGraph() throws Exception {
         Graph graph = new Graph("Test Graph");
-        GraphNode node1 = new GraphNode("Node A", 0);
+        UUID nodeAId = UuidV7Generator.generate();
+        UUID nodeBId = UuidV7Generator.generate();
+        GraphNode node1 = new GraphNode("Node A", nodeAId);
         node1.setGraph(graph);
-        GraphNode node2 = new GraphNode("Node B", 1);
+        GraphNode node2 = new GraphNode("Node B", nodeBId);
         node2.setGraph(graph);
         graph.getNodes().add(node1);
         graph.getNodes().add(node2);
@@ -179,7 +186,8 @@ class GraphControllerTest {
 
     @Test
     void shouldReturn404WhenListingNodesForNonExistentGraph() throws Exception {
-        mockMvc.perform(get("/graphs/999/nodes"))
+        UUID randomUuid = UuidV7Generator.generate();
+        mockMvc.perform(get("/graphs/" + randomUuid + "/nodes"))
                 .andExpect(status().isNotFound());
     }
 
@@ -208,7 +216,7 @@ class GraphControllerTest {
                 .andReturn().getResponse().getContentAsString();
 
         // Extract graph ID from response
-        int graphId = objectMapper.readTree(graphResponse).get("id").asInt();
+        String graphId = objectMapper.readTree(graphResponse).get("id").asText();
 
         // Add node via POST /graphs/{id} (the endpoint reported as failing)
         mockMvc.perform(post("/graphs/" + graphId)
@@ -228,7 +236,7 @@ class GraphControllerTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
 
-        int graphId = objectMapper.readTree(graphResponse).get("id").asInt();
+        String graphId = objectMapper.readTree(graphResponse).get("id").asText();
 
         // Add first node
         mockMvc.perform(post("/graphs/" + graphId)
@@ -262,7 +270,7 @@ class GraphControllerTest {
                 .andExpect(status().isCreated())
                 .andReturn().getResponse().getContentAsString();
 
-        int graphId = objectMapper.readTree(graphResponse).get("id").asInt();
+        String graphId = objectMapper.readTree(graphResponse).get("id").asText();
 
         // Flush and clear to simulate end of first HTTP request/transaction
         entityManager.flush();
@@ -288,7 +296,8 @@ class GraphControllerTest {
 
     @Test
     void shouldReturn404WhenCreatingNodeInNonExistentGraph() throws Exception {
-        mockMvc.perform(post("/graphs/999/nodes")
+        UUID randomUuid = UuidV7Generator.generate();
+        mockMvc.perform(post("/graphs/" + randomUuid + "/nodes")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"name\": \"New Node\"}"))
                 .andExpect(status().isNotFound());
@@ -308,17 +317,26 @@ class GraphControllerTest {
     // GET /graphs/{id}/nodes/{nodeId} - get a specific node with links
     @Test
     void shouldReturnNodeByIdWithLinks() throws Exception {
-        Graph graph = new Graph("Test Graph");
-        GraphNode node = new GraphNode("Node A", 0);
-        node.setGraph(graph);
-        graph.getNodes().add(node);
-        graph.setImmutableGraph(graph.getImmutableGraph().addNode("Node A").getGraph());
-        Graph savedGraph = graphRepository.save(graph);
-        Integer nodeId = savedGraph.getNodes().get(0).getId();
+        // Create graph and node via REST endpoints to ensure proper setup
+        String graphResponse = mockMvc.perform(post("/graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Test Graph\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
 
-        mockMvc.perform(get("/graphs/" + savedGraph.getId() + "/nodes/" + nodeId))
+        String graphId = objectMapper.readTree(graphResponse).get("id").asText();
+
+        String nodeResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node A\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeId = objectMapper.readTree(nodeResponse).get("id").asText();
+
+        mockMvc.perform(get("/graphs/" + graphId + "/nodes/" + nodeId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.node.graphNodeId").value(0))
+                .andExpect(jsonPath("$.node.id").value(nodeId))
                 .andExpect(jsonPath("$.node.name").value("Node A"))
                 .andExpect(jsonPath("$.toNodes").isArray())
                 .andExpect(jsonPath("$.toNodes.length()").value(0));
@@ -326,29 +344,49 @@ class GraphControllerTest {
 
     @Test
     void shouldReturnNodeWithLinkedNodes() throws Exception {
-        Graph graph = new Graph("Test Graph");
-        GraphNode node1 = new GraphNode("Node A", 0);
-        GraphNode node2 = new GraphNode("Node B", 1);
-        GraphNode node3 = new GraphNode("Node C", 2);
-        node1.setGraph(graph);
-        node2.setGraph(graph);
-        node3.setGraph(graph);
-        graph.getNodes().add(node1);
-        graph.getNodes().add(node2);
-        graph.getNodes().add(node3);
+        // Create graph
+        String graphResponse = mockMvc.perform(post("/graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Test Graph\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
 
-        // Build the immutable graph: A -> B and A -> C
-        graph.setImmutableGraph(graph.getImmutableGraph().addNode("Node A").getGraph());
-        graph.setImmutableGraph(graph.getImmutableGraph().addNode("Node B").getGraph());
-        graph.setImmutableGraph(graph.getImmutableGraph().addNode("Node C").getGraph());
-        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(0, 1, "edge"));
-        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(0, 2, "edge"));
-        Graph savedGraph = graphRepository.save(graph);
-        Integer nodeId = savedGraph.getNodes().get(0).getId();
+        String graphId = objectMapper.readTree(graphResponse).get("id").asText();
 
-        mockMvc.perform(get("/graphs/" + savedGraph.getId() + "/nodes/" + nodeId))
+        // Create nodes
+        String nodeAResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node A\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeBResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node B\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeCResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node C\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeAId = objectMapper.readTree(nodeAResponse).get("id").asText();
+        String nodeBId = objectMapper.readTree(nodeBResponse).get("id").asText();
+        String nodeCId = objectMapper.readTree(nodeCResponse).get("id").asText();
+
+        // Add edges: A -> B and A -> C
+        mockMvc.perform(post("/graphs/" + graphId + "/nodes/" + nodeAId + "/" + nodeBId))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/graphs/" + graphId + "/nodes/" + nodeAId + "/" + nodeCId))
+                .andExpect(status().isOk());
+
+        // Get node A with its links
+        mockMvc.perform(get("/graphs/" + graphId + "/nodes/" + nodeAId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.node.graphNodeId").value(0))
+                .andExpect(jsonPath("$.node.id").value(nodeAId))
                 .andExpect(jsonPath("$.node.name").value("Node A"))
                 .andExpect(jsonPath("$.toNodes").isArray())
                 .andExpect(jsonPath("$.toNodes.length()").value(2));
@@ -359,60 +397,94 @@ class GraphControllerTest {
         Graph graph = new Graph("Test Graph");
         Graph savedGraph = graphRepository.save(graph);
 
-        mockMvc.perform(get("/graphs/" + savedGraph.getId() + "/nodes/999"))
+        UUID randomUuid = UuidV7Generator.generate();
+        mockMvc.perform(get("/graphs/" + savedGraph.getId() + "/nodes/" + randomUuid))
                 .andExpect(status().isNotFound());
     }
 
     // POST /graphs/{id}/nodes/{fromId}/{toId} - add an edge
     @Test
     void shouldAddEdgeBetweenNodes() throws Exception {
-        Graph graph = new Graph("Test Graph");
-        GraphNode node1 = new GraphNode("Node A", 0);
-        node1.setGraph(graph);
-        GraphNode node2 = new GraphNode("Node B", 1);
-        node2.setGraph(graph);
-        graph.getNodes().add(node1);
-        graph.getNodes().add(node2);
-        graph.setImmutableGraph(graph.getImmutableGraph().addNode("Node A").getGraph());
-        graph.setImmutableGraph(graph.getImmutableGraph().addNode("Node B").getGraph());
-        Graph savedGraph = graphRepository.save(graph);
+        // Create graph and nodes via REST
+        String graphResponse = mockMvc.perform(post("/graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Test Graph\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
 
-        mockMvc.perform(post("/graphs/" + savedGraph.getId() + "/nodes/0/1"))
+        String graphId = objectMapper.readTree(graphResponse).get("id").asText();
+
+        String nodeAResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node A\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeBResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node B\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeAId = objectMapper.readTree(nodeAResponse).get("id").asText();
+        String nodeBId = objectMapper.readTree(nodeBResponse).get("id").asText();
+
+        mockMvc.perform(post("/graphs/" + graphId + "/nodes/" + nodeAId + "/" + nodeBId))
                 .andExpect(status().isOk());
     }
 
     @Test
     void shouldReturn404WhenAddingEdgeToNonExistentGraph() throws Exception {
-        mockMvc.perform(post("/graphs/999/nodes/0/1"))
+        UUID randomUuid = UuidV7Generator.generate();
+        UUID nodeAId = UuidV7Generator.generate();
+        UUID nodeBId = UuidV7Generator.generate();
+        mockMvc.perform(post("/graphs/" + randomUuid + "/nodes/" + nodeAId + "/" + nodeBId))
                 .andExpect(status().isNotFound());
     }
 
     // GET /graphs/{id}/dfs/{nodeId} - depth-first search
     @Test
     void shouldPerformDepthFirstSearch() throws Exception {
-        Graph graph = new Graph("Test Graph");
-        GraphNode node1 = new GraphNode("Node A", 0);
-        GraphNode node2 = new GraphNode("Node B", 1);
-        GraphNode node3 = new GraphNode("Node C", 2);
-        node1.setGraph(graph);
-        node2.setGraph(graph);
-        node3.setGraph(graph);
-        graph.getNodes().add(node1);
-        graph.getNodes().add(node2);
-        graph.getNodes().add(node3);
+        // Create graph
+        String graphResponse = mockMvc.perform(post("/graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Test Graph\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
 
-        // Build the immutable graph: A -> B -> C
-        var result1 = graph.getImmutableGraph().addNode("Node A");
-        graph.setImmutableGraph(result1.getGraph());
-        var result2 = graph.getImmutableGraph().addNode("Node B");
-        graph.setImmutableGraph(result2.getGraph());
-        var result3 = graph.getImmutableGraph().addNode("Node C");
-        graph.setImmutableGraph(result3.getGraph());
-        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(0, 1, "edge"));
-        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(1, 2, "edge"));
-        Graph savedGraph = graphRepository.save(graph);
+        String graphId = objectMapper.readTree(graphResponse).get("id").asText();
 
-        mockMvc.perform(get("/graphs/" + savedGraph.getId() + "/dfs/0"))
+        // Create nodes
+        String nodeAResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node A\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeBResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node B\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeCResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node C\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeAId = objectMapper.readTree(nodeAResponse).get("id").asText();
+        String nodeBId = objectMapper.readTree(nodeBResponse).get("id").asText();
+        String nodeCId = objectMapper.readTree(nodeCResponse).get("id").asText();
+
+        // Add edges: A -> B -> C
+        mockMvc.perform(post("/graphs/" + graphId + "/nodes/" + nodeAId + "/" + nodeBId))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/graphs/" + graphId + "/nodes/" + nodeBId + "/" + nodeCId))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/graphs/" + graphId + "/dfs/" + nodeAId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$.length()").value(3));
@@ -420,36 +492,55 @@ class GraphControllerTest {
 
     @Test
     void shouldReturn404WhenDFSOnNonExistentGraph() throws Exception {
-        mockMvc.perform(get("/graphs/999/dfs/0"))
+        UUID randomUuid = UuidV7Generator.generate();
+        UUID nodeId = UuidV7Generator.generate();
+        mockMvc.perform(get("/graphs/" + randomUuid + "/dfs/" + nodeId))
                 .andExpect(status().isNotFound());
     }
 
     // GET /graphs/{id}/bfs/{nodeId} - breadth-first search
     @Test
     void shouldPerformBreadthFirstSearch() throws Exception {
-        Graph graph = new Graph("Test Graph");
-        GraphNode node1 = new GraphNode("Node A", 0);
-        GraphNode node2 = new GraphNode("Node B", 1);
-        GraphNode node3 = new GraphNode("Node C", 2);
-        node1.setGraph(graph);
-        node2.setGraph(graph);
-        node3.setGraph(graph);
-        graph.getNodes().add(node1);
-        graph.getNodes().add(node2);
-        graph.getNodes().add(node3);
+        // Create graph
+        String graphResponse = mockMvc.perform(post("/graphs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Test Graph\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
 
-        // Build the immutable graph: A -> B -> C
-        var result1 = graph.getImmutableGraph().addNode("Node A");
-        graph.setImmutableGraph(result1.getGraph());
-        var result2 = graph.getImmutableGraph().addNode("Node B");
-        graph.setImmutableGraph(result2.getGraph());
-        var result3 = graph.getImmutableGraph().addNode("Node C");
-        graph.setImmutableGraph(result3.getGraph());
-        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(0, 1, "edge"));
-        graph.setImmutableGraph(graph.getImmutableGraph().addEdge(1, 2, "edge"));
-        Graph savedGraph = graphRepository.save(graph);
+        String graphId = objectMapper.readTree(graphResponse).get("id").asText();
 
-        mockMvc.perform(get("/graphs/" + savedGraph.getId() + "/bfs/0"))
+        // Create nodes
+        String nodeAResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node A\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeBResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node B\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeCResponse = mockMvc.perform(post("/graphs/" + graphId + "/nodes")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\": \"Node C\"}"))
+                .andExpect(status().isCreated())
+                .andReturn().getResponse().getContentAsString();
+
+        String nodeAId = objectMapper.readTree(nodeAResponse).get("id").asText();
+        String nodeBId = objectMapper.readTree(nodeBResponse).get("id").asText();
+        String nodeCId = objectMapper.readTree(nodeCResponse).get("id").asText();
+
+        // Add edges: A -> B -> C
+        mockMvc.perform(post("/graphs/" + graphId + "/nodes/" + nodeAId + "/" + nodeBId))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/graphs/" + graphId + "/nodes/" + nodeBId + "/" + nodeCId))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/graphs/" + graphId + "/bfs/" + nodeAId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$.length()").value(3));
@@ -457,7 +548,9 @@ class GraphControllerTest {
 
     @Test
     void shouldReturn404WhenBFSOnNonExistentGraph() throws Exception {
-        mockMvc.perform(get("/graphs/999/bfs/0"))
+        UUID randomUuid = UuidV7Generator.generate();
+        UUID nodeId = UuidV7Generator.generate();
+        mockMvc.perform(get("/graphs/" + randomUuid + "/bfs/" + nodeId))
                 .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/robsartin/graphs/infrastructure/ImmutableGraphTest.java
+++ b/src/test/java/com/robsartin/graphs/infrastructure/ImmutableGraphTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 class ImmutableGraphTest {
 
@@ -24,11 +25,11 @@ class ImmutableGraphTest {
 
         var gn1 = g0.addNode("A");
         ImmutableGraph<String, Integer> g1 = gn1.getGraph();
-        int nodeA = gn1.getNodeId();
+        UUID nodeA = gn1.getNodeId();
 
         var gn2 = g1.addNode("B");
         ImmutableGraph<String, Integer> g2 = gn2.getGraph();
-        int nodeB = gn2.getNodeId();
+        UUID nodeB = gn2.getNodeId();
 
         // Original graph unchanged
         assertEquals(0, g0.nodeCount());
@@ -53,9 +54,9 @@ class ImmutableGraphTest {
         var gn3 = gn2.getGraph().addNode("C");
 
         ImmutableGraph<String, Integer> g1 = gn3.getGraph();
-        int nodeA = gn1.getNodeId();
-        int nodeB = gn2.getNodeId();
-        int nodeC = gn3.getNodeId();
+        UUID nodeA = gn1.getNodeId();
+        UUID nodeB = gn2.getNodeId();
+        UUID nodeC = gn3.getNodeId();
 
         ImmutableGraph<String, Integer> g2 = g1.addEdge(nodeA, nodeB, 10);
         ImmutableGraph<String, Integer> g3 = g2.addEdge(nodeB, nodeC, 20);
@@ -87,8 +88,8 @@ class ImmutableGraphTest {
         var gn2 = gn1.getGraph().addNode("B");
 
         ImmutableGraph<String, Integer> g1 = gn2.getGraph();
-        int nodeA = gn1.getNodeId();
-        int nodeB = gn2.getNodeId();
+        UUID nodeA = gn1.getNodeId();
+        UUID nodeB = gn2.getNodeId();
 
         g1 = g1.addEdge(nodeA, nodeB, 10);
 
@@ -108,8 +109,9 @@ class ImmutableGraphTest {
     @Test
     @DisplayName("Depth-first traversal")
     void testDepthFirstTraversal() {
-        ImmutableGraph<String, Integer> graph = buildTestGraph();
-        int startNode = 0;  // Node "A"
+        TestGraph testGraph = buildTestGraph();
+        ImmutableGraph<String, Integer> graph = testGraph.graph;
+        UUID startNode = testGraph.nodeA;
 
         List<String> visited = new ArrayList<>();
         graph.depthFirstTraversal(startNode, ctx -> visited.add(ctx.getLabel()));
@@ -130,8 +132,9 @@ class ImmutableGraphTest {
     @Test
     @DisplayName("Breadth-first traversal")
     void testBreadthFirstTraversal() {
-        ImmutableGraph<String, Integer> graph = buildTestGraph();
-        int startNode = 0;  // Node "A"
+        TestGraph testGraph = buildTestGraph();
+        ImmutableGraph<String, Integer> graph = testGraph.graph;
+        UUID startNode = testGraph.nodeA;
 
         List<String> visited = new ArrayList<>();
         graph.breadthFirstTraversal(startNode, ctx -> visited.add(ctx.getLabel()));
@@ -151,13 +154,15 @@ class ImmutableGraphTest {
     @Test
     @DisplayName("Multiple traversals on same graph (immutability test)")
     void testMultipleTraversals() {
-        ImmutableGraph<String, Integer> graph = buildTestGraph();
+        TestGraph testGraph = buildTestGraph();
+        ImmutableGraph<String, Integer> graph = testGraph.graph;
+        UUID startNode = testGraph.nodeA;
 
         List<String> firstTraversal = new ArrayList<>();
-        graph.depthFirstTraversal(0, ctx -> firstTraversal.add(ctx.getLabel()));
+        graph.depthFirstTraversal(startNode, ctx -> firstTraversal.add(ctx.getLabel()));
 
         List<String> secondTraversal = new ArrayList<>();
-        graph.depthFirstTraversal(0, ctx -> secondTraversal.add(ctx.getLabel()));
+        graph.depthFirstTraversal(startNode, ctx -> secondTraversal.add(ctx.getLabel()));
 
         assertEquals(firstTraversal, secondTraversal);
         assertEquals(4, graph.nodeCount());
@@ -171,8 +176,8 @@ class ImmutableGraphTest {
         var gn2 = gn1.getGraph().addNode("B");
 
         ImmutableGraph<String, Integer> g1 = gn2.getGraph();
-        int nodeA = gn1.getNodeId();
-        int nodeB = gn2.getNodeId();
+        UUID nodeA = gn1.getNodeId();
+        UUID nodeB = gn2.getNodeId();
 
         g1 = g1.addEdge(nodeA, nodeB, 10);
 
@@ -188,11 +193,16 @@ class ImmutableGraphTest {
     }
 
     /**
+     * Helper record to hold a test graph with its node IDs
+     */
+    private record TestGraph(ImmutableGraph<String, Integer> graph, UUID nodeA, UUID nodeB, UUID nodeC, UUID nodeD) {}
+
+    /**
      * Build a test graph:
      *     A -> B -> D
      *     A -> C
      */
-    private ImmutableGraph<String, Integer> buildTestGraph() {
+    private TestGraph buildTestGraph() {
         ImmutableGraph<String, Integer> g0 = new ImmutableGraph<>();
 
         var gn1 = g0.addNode("A");
@@ -202,15 +212,15 @@ class ImmutableGraphTest {
 
         ImmutableGraph<String, Integer> g = gn4.getGraph();
 
-        int nodeA = gn1.getNodeId();
-        int nodeB = gn2.getNodeId();
-        int nodeC = gn3.getNodeId();
-        int nodeD = gn4.getNodeId();
+        UUID nodeA = gn1.getNodeId();
+        UUID nodeB = gn2.getNodeId();
+        UUID nodeC = gn3.getNodeId();
+        UUID nodeD = gn4.getNodeId();
 
         g = g.addEdge(nodeA, nodeB, 1);
         g = g.addEdge(nodeA, nodeC, 2);
         g = g.addEdge(nodeB, nodeD, 3);
 
-        return g;
+        return new TestGraph(g, nodeA, nodeB, nodeC, nodeD);
     }
 }


### PR DESCRIPTION
- Create UuidV7Generator utility class for generating time-ordered UUIDs
- Update ImmutableGraph to use UUID for nodeId instead of int
- Update all entity classes (GraphNode, ImmutableGraphNodeEntity, ImmutableGraphEdgeEntity, ImmutableGraphEntity, Graph) to use UUID as primary identifiers
- Update repository interfaces and adapters for UUID support
- Update GraphController and ImmutableGraphController to use UUID in path variables and DTOs
- Update CorrelationIdContext to use UuidV7Generator
- Update all tests to work with UUID identifiers
- Remove redundant graphNodeId field - unified with entity id

This change provides consistent UUID v7 identifiers across the entire codebase, enabling time-ordered, globally unique identifiers for all graph-related entities.