### PR TITLE
feat: enable LRU caching for all service layers using Caffeine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,16 @@
             <version>${openfeature.version}</version>
         </dependency>
 
+        <!-- Spring Boot Cache with Caffeine -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
         <!-- jMolecules -->
         <dependency>
             <groupId>org.jmolecules</groupId>

--- a/src/main/java/com/robsartin/graphs/config/CacheConfiguration.java
+++ b/src/main/java/com/robsartin/graphs/config/CacheConfiguration.java
@@ -1,0 +1,78 @@
+package com.robsartin.graphs.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration for application caching using Caffeine.
+ * All caches are configured with LRU (Least Recently Used) eviction policy.
+ */
+@Configuration
+@EnableCaching
+public class CacheConfiguration {
+
+    public static final String GRAPHS_CACHE = "graphs";
+    public static final String GRAPH_BY_ID_CACHE = "graphById";
+    public static final String IMMUTABLE_GRAPHS_CACHE = "immutableGraphs";
+    public static final String IMMUTABLE_GRAPH_BY_ID_CACHE = "immutableGraphById";
+    public static final String FEATURE_FLAGS_CACHE = "featureFlags";
+
+    private static final int DEFAULT_MAX_SIZE = 100;
+    private static final int FEATURE_FLAGS_MAX_SIZE = 50;
+    private static final long FEATURE_FLAGS_EXPIRE_MINUTES = 5;
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCaffeine(defaultCacheBuilder());
+        cacheManager.registerCustomCache(GRAPHS_CACHE, graphsCacheBuilder().build());
+        cacheManager.registerCustomCache(GRAPH_BY_ID_CACHE, graphByIdCacheBuilder().build());
+        cacheManager.registerCustomCache(IMMUTABLE_GRAPHS_CACHE, immutableGraphsCacheBuilder().build());
+        cacheManager.registerCustomCache(IMMUTABLE_GRAPH_BY_ID_CACHE, immutableGraphByIdCacheBuilder().build());
+        cacheManager.registerCustomCache(FEATURE_FLAGS_CACHE, featureFlagsCacheBuilder().build());
+        return cacheManager;
+    }
+
+    private Caffeine<Object, Object> defaultCacheBuilder() {
+        return Caffeine.newBuilder()
+            .maximumSize(DEFAULT_MAX_SIZE)
+            .recordStats();
+    }
+
+    private Caffeine<Object, Object> graphsCacheBuilder() {
+        return Caffeine.newBuilder()
+            .maximumSize(1) // Only one "all graphs" result
+            .recordStats();
+    }
+
+    private Caffeine<Object, Object> graphByIdCacheBuilder() {
+        return Caffeine.newBuilder()
+            .maximumSize(DEFAULT_MAX_SIZE)
+            .recordStats();
+    }
+
+    private Caffeine<Object, Object> immutableGraphsCacheBuilder() {
+        return Caffeine.newBuilder()
+            .maximumSize(1) // Only one "all graphs" result
+            .recordStats();
+    }
+
+    private Caffeine<Object, Object> immutableGraphByIdCacheBuilder() {
+        return Caffeine.newBuilder()
+            .maximumSize(DEFAULT_MAX_SIZE)
+            .recordStats();
+    }
+
+    private Caffeine<Object, Object> featureFlagsCacheBuilder() {
+        return Caffeine.newBuilder()
+            .maximumSize(FEATURE_FLAGS_MAX_SIZE)
+            .expireAfterWrite(FEATURE_FLAGS_EXPIRE_MINUTES, TimeUnit.MINUTES)
+            .recordStats();
+    }
+}

--- a/src/main/java/com/robsartin/graphs/infrastructure/FeatureFlagService.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/FeatureFlagService.java
@@ -1,7 +1,9 @@
 package com.robsartin.graphs.infrastructure;
 
+import com.robsartin.graphs.config.CacheConfiguration;
 import com.robsartin.graphs.config.OpenFeatureConfiguration;
 import dev.openfeature.sdk.Client;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 /**
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Service;
  * This service provides a clean interface for checking feature flags
  * throughout the application. It wraps the OpenFeature Client to provide
  * type-safe methods for specific feature flags.
+ * Feature flag results are cached with LRU eviction and time-based expiration.
  */
 @Service
 public class FeatureFlagService {
@@ -22,9 +25,11 @@ public class FeatureFlagService {
 
     /**
      * Checks if the graph delete functionality is enabled.
+     * Results are cached to reduce external calls.
      *
      * @return true if graph deletion is enabled, false otherwise
      */
+    @Cacheable(value = CacheConfiguration.FEATURE_FLAGS_CACHE, key = "'" + OpenFeatureConfiguration.FLAG_DELETE_ENABLED + "'")
     public boolean isDeleteEnabled() {
         return client.getBooleanValue(OpenFeatureConfiguration.FLAG_DELETE_ENABLED, false);
     }

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapter.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapter.java
@@ -1,7 +1,11 @@
 package com.robsartin.graphs.infrastructure.adapters.persistence;
 
+import com.robsartin.graphs.config.CacheConfiguration;
 import com.robsartin.graphs.models.Graph;
 import com.robsartin.graphs.ports.out.GraphRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -11,6 +15,7 @@ import java.util.UUID;
 /**
  * Adapter that implements the GraphRepository port using Spring Data JPA.
  * This adapter translates between the domain port interface and the JPA repository.
+ * All read operations are cached with LRU eviction policy.
  */
 @Component
 public class GraphRepositoryAdapter implements GraphRepository {
@@ -22,21 +27,31 @@ public class GraphRepositoryAdapter implements GraphRepository {
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfiguration.GRAPHS_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfiguration.GRAPH_BY_ID_CACHE, key = "#graph.id", condition = "#graph.id != null")
+    })
     public Graph save(Graph graph) {
         return jpaGraphRepository.save(graph);
     }
 
     @Override
+    @Cacheable(value = CacheConfiguration.GRAPH_BY_ID_CACHE, key = "#id")
     public Optional<Graph> findById(UUID id) {
         return jpaGraphRepository.findById(id);
     }
 
     @Override
+    @Cacheable(value = CacheConfiguration.GRAPHS_CACHE)
     public List<Graph> findAll() {
         return jpaGraphRepository.findAll();
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfiguration.GRAPHS_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfiguration.GRAPH_BY_ID_CACHE, key = "#id")
+    })
     public void deleteById(UUID id) {
         jpaGraphRepository.deleteById(id);
     }
@@ -47,6 +62,10 @@ public class GraphRepositoryAdapter implements GraphRepository {
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfiguration.GRAPHS_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfiguration.GRAPH_BY_ID_CACHE, allEntries = true)
+    })
     public void deleteAll() {
         jpaGraphRepository.deleteAll();
     }

--- a/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/ImmutableGraphRepositoryAdapter.java
+++ b/src/main/java/com/robsartin/graphs/infrastructure/adapters/persistence/ImmutableGraphRepositoryAdapter.java
@@ -1,7 +1,11 @@
 package com.robsartin.graphs.infrastructure.adapters.persistence;
 
+import com.robsartin.graphs.config.CacheConfiguration;
 import com.robsartin.graphs.models.ImmutableGraphEntity;
 import com.robsartin.graphs.ports.out.ImmutableGraphRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -11,6 +15,7 @@ import java.util.UUID;
 /**
  * Adapter that implements the ImmutableGraphRepository port using Spring Data JPA.
  * This adapter translates between the domain port interface and the JPA repository.
+ * All read operations are cached with LRU eviction policy.
  */
 @Component
 public class ImmutableGraphRepositoryAdapter implements ImmutableGraphRepository {
@@ -22,21 +27,31 @@ public class ImmutableGraphRepositoryAdapter implements ImmutableGraphRepository
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfiguration.IMMUTABLE_GRAPHS_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfiguration.IMMUTABLE_GRAPH_BY_ID_CACHE, key = "#graph.id", condition = "#graph.id != null")
+    })
     public ImmutableGraphEntity save(ImmutableGraphEntity graph) {
         return jpaImmutableGraphRepository.save(graph);
     }
 
     @Override
+    @Cacheable(value = CacheConfiguration.IMMUTABLE_GRAPH_BY_ID_CACHE, key = "#id")
     public Optional<ImmutableGraphEntity> findById(UUID id) {
         return jpaImmutableGraphRepository.findById(id);
     }
 
     @Override
+    @Cacheable(value = CacheConfiguration.IMMUTABLE_GRAPHS_CACHE)
     public List<ImmutableGraphEntity> findAll() {
         return jpaImmutableGraphRepository.findAll();
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfiguration.IMMUTABLE_GRAPHS_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfiguration.IMMUTABLE_GRAPH_BY_ID_CACHE, key = "#id")
+    })
     public void deleteById(UUID id) {
         jpaImmutableGraphRepository.deleteById(id);
     }
@@ -47,6 +62,10 @@ public class ImmutableGraphRepositoryAdapter implements ImmutableGraphRepository
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(value = CacheConfiguration.IMMUTABLE_GRAPHS_CACHE, allEntries = true),
+        @CacheEvict(value = CacheConfiguration.IMMUTABLE_GRAPH_BY_ID_CACHE, allEntries = true)
+    })
     public void deleteAll() {
         jpaImmutableGraphRepository.deleteAll();
     }

--- a/src/test/java/com/robsartin/graphs/config/CacheConfigurationTest.java
+++ b/src/test/java/com/robsartin/graphs/config/CacheConfigurationTest.java
@@ -1,0 +1,102 @@
+package com.robsartin.graphs.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.context.annotation.Import;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Import(TestOpenFeatureConfiguration.class)
+class CacheConfigurationTest {
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Test
+    void shouldCreateGraphsCache() {
+        var cache = cacheManager.getCache(CacheConfiguration.GRAPHS_CACHE);
+        assertNotNull(cache, "Graphs cache should exist");
+    }
+
+    @Test
+    void shouldCreateGraphByIdCache() {
+        var cache = cacheManager.getCache(CacheConfiguration.GRAPH_BY_ID_CACHE);
+        assertNotNull(cache, "Graph by ID cache should exist");
+    }
+
+    @Test
+    void shouldCreateImmutableGraphsCache() {
+        var cache = cacheManager.getCache(CacheConfiguration.IMMUTABLE_GRAPHS_CACHE);
+        assertNotNull(cache, "Immutable graphs cache should exist");
+    }
+
+    @Test
+    void shouldCreateImmutableGraphByIdCache() {
+        var cache = cacheManager.getCache(CacheConfiguration.IMMUTABLE_GRAPH_BY_ID_CACHE);
+        assertNotNull(cache, "Immutable graph by ID cache should exist");
+    }
+
+    @Test
+    void shouldCreateFeatureFlagsCache() {
+        var cache = cacheManager.getCache(CacheConfiguration.FEATURE_FLAGS_CACHE);
+        assertNotNull(cache, "Feature flags cache should exist");
+    }
+
+    @Test
+    void shouldHaveLruEvictionPolicy() {
+        var cache = cacheManager.getCache(CacheConfiguration.GRAPH_BY_ID_CACHE);
+        assertNotNull(cache);
+        assertInstanceOf(CaffeineCache.class, cache, "Cache should be a Caffeine cache for LRU support");
+
+        CaffeineCache caffeineCache = (CaffeineCache) cache;
+        Cache<Object, Object> nativeCache = caffeineCache.getNativeCache();
+
+        // Fill the cache beyond its maximum size
+        for (int i = 0; i < 150; i++) {
+            nativeCache.put("key" + i, "value" + i);
+        }
+
+        // Trigger cleanup
+        nativeCache.cleanUp();
+
+        // Should be at or below maximum size (100) after eviction
+        assertTrue(nativeCache.estimatedSize() <= 100,
+            "Cache should evict entries when exceeding max size. Size: " + nativeCache.estimatedSize());
+    }
+
+    @Test
+    void shouldEvictLeastRecentlyUsedEntries() {
+        var cache = cacheManager.getCache(CacheConfiguration.GRAPH_BY_ID_CACHE);
+        assertNotNull(cache);
+        CaffeineCache caffeineCache = (CaffeineCache) cache;
+        Cache<Object, Object> nativeCache = caffeineCache.getNativeCache();
+
+        // Clear the cache first
+        nativeCache.invalidateAll();
+
+        // Add entries up to max size
+        for (int i = 0; i < 100; i++) {
+            nativeCache.put("key" + i, "value" + i);
+        }
+
+        // Access key0 to make it recently used
+        nativeCache.getIfPresent("key0");
+
+        // Add more entries to trigger eviction
+        for (int i = 100; i < 150; i++) {
+            nativeCache.put("key" + i, "value" + i);
+        }
+
+        // Trigger cleanup
+        nativeCache.cleanUp();
+
+        // key0 should still be present (recently used)
+        assertNotNull(nativeCache.getIfPresent("key0"),
+            "Recently accessed entry should not be evicted");
+    }
+}

--- a/src/test/java/com/robsartin/graphs/infrastructure/FeatureFlagServiceCacheTest.java
+++ b/src/test/java/com/robsartin/graphs/infrastructure/FeatureFlagServiceCacheTest.java
@@ -1,0 +1,77 @@
+package com.robsartin.graphs.infrastructure;
+
+import com.robsartin.graphs.config.CacheConfiguration;
+import com.robsartin.graphs.config.OpenFeatureConfiguration;
+import com.robsartin.graphs.config.TestOpenFeatureConfiguration;
+import dev.openfeature.sdk.Client;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Import(TestOpenFeatureConfiguration.class)
+class FeatureFlagServiceCacheTest {
+
+    @Autowired
+    private FeatureFlagService featureFlagService;
+
+    @SpyBean
+    private Client openFeatureClient;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        // Clear cache before each test
+        Objects.requireNonNull(cacheManager.getCache(CacheConfiguration.FEATURE_FLAGS_CACHE)).clear();
+        reset(openFeatureClient);
+    }
+
+    @Test
+    void isDeleteEnabledShouldCacheResult() {
+        // When - call isDeleteEnabled multiple times
+        featureFlagService.isDeleteEnabled();
+        featureFlagService.isDeleteEnabled();
+        featureFlagService.isDeleteEnabled();
+
+        // Then - OpenFeature client should only be called once
+        verify(openFeatureClient, times(1))
+            .getBooleanValue(eq(OpenFeatureConfiguration.FLAG_DELETE_ENABLED), anyBoolean());
+    }
+
+    @Test
+    void isDeleteEnabledShouldReturnCachedValue() {
+        // When - call isDeleteEnabled multiple times
+        boolean result1 = featureFlagService.isDeleteEnabled();
+        boolean result2 = featureFlagService.isDeleteEnabled();
+        boolean result3 = featureFlagService.isDeleteEnabled();
+
+        // Then - all results should be the same
+        assertEquals(result1, result2);
+        assertEquals(result2, result3);
+    }
+
+    @Test
+    void cachedValueShouldBePresentInCache() {
+        // When - call isDeleteEnabled
+        boolean result = featureFlagService.isDeleteEnabled();
+
+        // Then - value should be in cache
+        var cache = cacheManager.getCache(CacheConfiguration.FEATURE_FLAGS_CACHE);
+        assertNotNull(cache);
+
+        var cachedValue = cache.get(OpenFeatureConfiguration.FLAG_DELETE_ENABLED);
+        assertNotNull(cachedValue, "Cached value should be present");
+        assertEquals(result, cachedValue.get());
+    }
+}

--- a/src/test/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapterCacheTest.java
+++ b/src/test/java/com/robsartin/graphs/infrastructure/adapters/persistence/GraphRepositoryAdapterCacheTest.java
@@ -1,0 +1,182 @@
+package com.robsartin.graphs.infrastructure.adapters.persistence;
+
+import com.robsartin.graphs.config.CacheConfiguration;
+import com.robsartin.graphs.config.TestOpenFeatureConfiguration;
+import com.robsartin.graphs.models.Graph;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Import(TestOpenFeatureConfiguration.class)
+@Transactional
+class GraphRepositoryAdapterCacheTest {
+
+    @Autowired
+    private GraphRepositoryAdapter graphRepositoryAdapter;
+
+    @SpyBean
+    private JpaGraphRepository jpaGraphRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        // Clear all caches before each test
+        Objects.requireNonNull(cacheManager.getCache(CacheConfiguration.GRAPHS_CACHE)).clear();
+        Objects.requireNonNull(cacheManager.getCache(CacheConfiguration.GRAPH_BY_ID_CACHE)).clear();
+        jpaGraphRepository.deleteAll();
+        reset(jpaGraphRepository);
+    }
+
+    @Test
+    void findAllShouldCacheResult() {
+        // Given
+        Graph graph = new Graph("Test Graph");
+        jpaGraphRepository.save(graph);
+        reset(jpaGraphRepository); // Reset to count only subsequent calls
+
+        // When - call findAll twice
+        graphRepositoryAdapter.findAll();
+        graphRepositoryAdapter.findAll();
+
+        // Then - JPA repository should only be called once (second call uses cache)
+        verify(jpaGraphRepository, times(1)).findAll();
+    }
+
+    @Test
+    void findByIdShouldCacheResult() {
+        // Given
+        Graph graph = new Graph("Test Graph");
+        Graph savedGraph = jpaGraphRepository.save(graph);
+        UUID graphId = savedGraph.getId();
+        reset(jpaGraphRepository);
+
+        // When - call findById twice with same ID
+        graphRepositoryAdapter.findById(graphId);
+        graphRepositoryAdapter.findById(graphId);
+
+        // Then - JPA repository should only be called once
+        verify(jpaGraphRepository, times(1)).findById(graphId);
+    }
+
+    @Test
+    void findByIdShouldCacheEmptyResult() {
+        // Given
+        UUID nonExistentId = UUID.randomUUID();
+
+        // When - call findById twice for non-existent ID
+        Optional<Graph> result1 = graphRepositoryAdapter.findById(nonExistentId);
+        Optional<Graph> result2 = graphRepositoryAdapter.findById(nonExistentId);
+
+        // Then - JPA repository should only be called once
+        verify(jpaGraphRepository, times(1)).findById(nonExistentId);
+        assertTrue(result1.isEmpty());
+        assertTrue(result2.isEmpty());
+    }
+
+    @Test
+    void saveShouldEvictAllCaches() {
+        // Given - populate caches
+        Graph graph1 = new Graph("Graph 1");
+        jpaGraphRepository.save(graph1);
+        graphRepositoryAdapter.findAll(); // Populate findAll cache
+        graphRepositoryAdapter.findById(graph1.getId()); // Populate findById cache
+        reset(jpaGraphRepository);
+
+        // When - save a new graph
+        Graph graph2 = new Graph("Graph 2");
+        graphRepositoryAdapter.save(graph2);
+
+        // Then - subsequent findAll should hit the database (cache was evicted)
+        graphRepositoryAdapter.findAll();
+        verify(jpaGraphRepository, times(1)).findAll();
+    }
+
+    @Test
+    void saveShouldEvictFindByIdCache() {
+        // Given - populate cache
+        Graph graph = new Graph("Test Graph");
+        Graph savedGraph = jpaGraphRepository.save(graph);
+        graphRepositoryAdapter.findById(savedGraph.getId());
+        reset(jpaGraphRepository);
+
+        // When - save the graph again (update)
+        savedGraph.setName("Updated Graph");
+        graphRepositoryAdapter.save(savedGraph);
+
+        // Then - subsequent findById should hit the database
+        graphRepositoryAdapter.findById(savedGraph.getId());
+        verify(jpaGraphRepository, times(1)).findById(savedGraph.getId());
+    }
+
+    @Test
+    void deleteByIdShouldEvictAllCaches() {
+        // Given - populate caches
+        Graph graph = new Graph("Test Graph");
+        Graph savedGraph = jpaGraphRepository.save(graph);
+        graphRepositoryAdapter.findAll();
+        graphRepositoryAdapter.findById(savedGraph.getId());
+        reset(jpaGraphRepository);
+
+        // When - delete the graph
+        graphRepositoryAdapter.deleteById(savedGraph.getId());
+
+        // Then - subsequent findAll and findById should hit the database
+        graphRepositoryAdapter.findAll();
+        graphRepositoryAdapter.findById(savedGraph.getId());
+
+        verify(jpaGraphRepository, times(1)).findAll();
+        verify(jpaGraphRepository, times(1)).findById(savedGraph.getId());
+    }
+
+    @Test
+    void deleteAllShouldEvictAllCaches() {
+        // Given - populate caches
+        Graph graph = new Graph("Test Graph");
+        Graph savedGraph = jpaGraphRepository.save(graph);
+        graphRepositoryAdapter.findAll();
+        graphRepositoryAdapter.findById(savedGraph.getId());
+        reset(jpaGraphRepository);
+
+        // When - delete all
+        graphRepositoryAdapter.deleteAll();
+
+        // Then - subsequent findAll should hit the database
+        graphRepositoryAdapter.findAll();
+        verify(jpaGraphRepository, times(1)).findAll();
+    }
+
+    @Test
+    void differentIdsShouldBeCachedSeparately() {
+        // Given
+        Graph graph1 = new Graph("Graph 1");
+        Graph graph2 = new Graph("Graph 2");
+        Graph saved1 = jpaGraphRepository.save(graph1);
+        Graph saved2 = jpaGraphRepository.save(graph2);
+        reset(jpaGraphRepository);
+
+        // When - call findById for both IDs multiple times
+        graphRepositoryAdapter.findById(saved1.getId());
+        graphRepositoryAdapter.findById(saved2.getId());
+        graphRepositoryAdapter.findById(saved1.getId());
+        graphRepositoryAdapter.findById(saved2.getId());
+
+        // Then - each ID should only hit the database once
+        verify(jpaGraphRepository, times(1)).findById(saved1.getId());
+        verify(jpaGraphRepository, times(1)).findById(saved2.getId());
+    }
+}

--- a/src/test/java/com/robsartin/graphs/infrastructure/adapters/persistence/ImmutableGraphRepositoryAdapterCacheTest.java
+++ b/src/test/java/com/robsartin/graphs/infrastructure/adapters/persistence/ImmutableGraphRepositoryAdapterCacheTest.java
@@ -1,0 +1,191 @@
+package com.robsartin.graphs.infrastructure.adapters.persistence;
+
+import com.robsartin.graphs.config.CacheConfiguration;
+import com.robsartin.graphs.config.TestOpenFeatureConfiguration;
+import com.robsartin.graphs.models.ImmutableGraphEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Import(TestOpenFeatureConfiguration.class)
+@Transactional
+class ImmutableGraphRepositoryAdapterCacheTest {
+
+    @Autowired
+    private ImmutableGraphRepositoryAdapter immutableGraphRepositoryAdapter;
+
+    @SpyBean
+    private JpaImmutableGraphRepository jpaImmutableGraphRepository;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @BeforeEach
+    void setUp() {
+        // Clear all caches before each test
+        Objects.requireNonNull(cacheManager.getCache(CacheConfiguration.IMMUTABLE_GRAPHS_CACHE)).clear();
+        Objects.requireNonNull(cacheManager.getCache(CacheConfiguration.IMMUTABLE_GRAPH_BY_ID_CACHE)).clear();
+        jpaImmutableGraphRepository.deleteAll();
+        reset(jpaImmutableGraphRepository);
+    }
+
+    @Test
+    void findAllShouldCacheResult() {
+        // Given
+        ImmutableGraphEntity graph = new ImmutableGraphEntity();
+        graph.setName("Test Graph");
+        jpaImmutableGraphRepository.save(graph);
+        reset(jpaImmutableGraphRepository);
+
+        // When - call findAll twice
+        immutableGraphRepositoryAdapter.findAll();
+        immutableGraphRepositoryAdapter.findAll();
+
+        // Then - JPA repository should only be called once
+        verify(jpaImmutableGraphRepository, times(1)).findAll();
+    }
+
+    @Test
+    void findByIdShouldCacheResult() {
+        // Given
+        ImmutableGraphEntity graph = new ImmutableGraphEntity();
+        graph.setName("Test Graph");
+        ImmutableGraphEntity savedGraph = jpaImmutableGraphRepository.save(graph);
+        UUID graphId = savedGraph.getId();
+        reset(jpaImmutableGraphRepository);
+
+        // When - call findById twice with same ID
+        immutableGraphRepositoryAdapter.findById(graphId);
+        immutableGraphRepositoryAdapter.findById(graphId);
+
+        // Then - JPA repository should only be called once
+        verify(jpaImmutableGraphRepository, times(1)).findById(graphId);
+    }
+
+    @Test
+    void findByIdShouldCacheEmptyResult() {
+        // Given
+        UUID nonExistentId = UUID.randomUUID();
+
+        // When - call findById twice for non-existent ID
+        Optional<ImmutableGraphEntity> result1 = immutableGraphRepositoryAdapter.findById(nonExistentId);
+        Optional<ImmutableGraphEntity> result2 = immutableGraphRepositoryAdapter.findById(nonExistentId);
+
+        // Then - JPA repository should only be called once
+        verify(jpaImmutableGraphRepository, times(1)).findById(nonExistentId);
+        assertTrue(result1.isEmpty());
+        assertTrue(result2.isEmpty());
+    }
+
+    @Test
+    void saveShouldEvictAllCaches() {
+        // Given - populate caches
+        ImmutableGraphEntity graph1 = new ImmutableGraphEntity();
+        graph1.setName("Graph 1");
+        jpaImmutableGraphRepository.save(graph1);
+        immutableGraphRepositoryAdapter.findAll();
+        immutableGraphRepositoryAdapter.findById(graph1.getId());
+        reset(jpaImmutableGraphRepository);
+
+        // When - save a new graph
+        ImmutableGraphEntity graph2 = new ImmutableGraphEntity();
+        graph2.setName("Graph 2");
+        immutableGraphRepositoryAdapter.save(graph2);
+
+        // Then - subsequent findAll should hit the database
+        immutableGraphRepositoryAdapter.findAll();
+        verify(jpaImmutableGraphRepository, times(1)).findAll();
+    }
+
+    @Test
+    void saveShouldEvictFindByIdCache() {
+        // Given - populate cache
+        ImmutableGraphEntity graph = new ImmutableGraphEntity();
+        graph.setName("Test Graph");
+        ImmutableGraphEntity savedGraph = jpaImmutableGraphRepository.save(graph);
+        immutableGraphRepositoryAdapter.findById(savedGraph.getId());
+        reset(jpaImmutableGraphRepository);
+
+        // When - save the graph again (update)
+        savedGraph.setName("Updated Graph");
+        immutableGraphRepositoryAdapter.save(savedGraph);
+
+        // Then - subsequent findById should hit the database
+        immutableGraphRepositoryAdapter.findById(savedGraph.getId());
+        verify(jpaImmutableGraphRepository, times(1)).findById(savedGraph.getId());
+    }
+
+    @Test
+    void deleteByIdShouldEvictAllCaches() {
+        // Given - populate caches
+        ImmutableGraphEntity graph = new ImmutableGraphEntity();
+        graph.setName("Test Graph");
+        ImmutableGraphEntity savedGraph = jpaImmutableGraphRepository.save(graph);
+        immutableGraphRepositoryAdapter.findAll();
+        immutableGraphRepositoryAdapter.findById(savedGraph.getId());
+        reset(jpaImmutableGraphRepository);
+
+        // When - delete the graph
+        immutableGraphRepositoryAdapter.deleteById(savedGraph.getId());
+
+        // Then - subsequent findAll and findById should hit the database
+        immutableGraphRepositoryAdapter.findAll();
+        immutableGraphRepositoryAdapter.findById(savedGraph.getId());
+
+        verify(jpaImmutableGraphRepository, times(1)).findAll();
+        verify(jpaImmutableGraphRepository, times(1)).findById(savedGraph.getId());
+    }
+
+    @Test
+    void deleteAllShouldEvictAllCaches() {
+        // Given - populate caches
+        ImmutableGraphEntity graph = new ImmutableGraphEntity();
+        graph.setName("Test Graph");
+        ImmutableGraphEntity savedGraph = jpaImmutableGraphRepository.save(graph);
+        immutableGraphRepositoryAdapter.findAll();
+        immutableGraphRepositoryAdapter.findById(savedGraph.getId());
+        reset(jpaImmutableGraphRepository);
+
+        // When - delete all
+        immutableGraphRepositoryAdapter.deleteAll();
+
+        // Then - subsequent findAll should hit the database
+        immutableGraphRepositoryAdapter.findAll();
+        verify(jpaImmutableGraphRepository, times(1)).findAll();
+    }
+
+    @Test
+    void differentIdsShouldBeCachedSeparately() {
+        // Given
+        ImmutableGraphEntity graph1 = new ImmutableGraphEntity();
+        graph1.setName("Graph 1");
+        ImmutableGraphEntity graph2 = new ImmutableGraphEntity();
+        graph2.setName("Graph 2");
+        ImmutableGraphEntity saved1 = jpaImmutableGraphRepository.save(graph1);
+        ImmutableGraphEntity saved2 = jpaImmutableGraphRepository.save(graph2);
+        reset(jpaImmutableGraphRepository);
+
+        // When - call findById for both IDs multiple times
+        immutableGraphRepositoryAdapter.findById(saved1.getId());
+        immutableGraphRepositoryAdapter.findById(saved2.getId());
+        immutableGraphRepositoryAdapter.findById(saved1.getId());
+        immutableGraphRepositoryAdapter.findById(saved2.getId());
+
+        // Then - each ID should only hit the database once
+        verify(jpaImmutableGraphRepository, times(1)).findById(saved1.getId());
+        verify(jpaImmutableGraphRepository, times(1)).findById(saved2.getId());
+    }
+}


### PR DESCRIPTION
Add caching infrastructure using Spring Boot's cache abstraction with Caffeine as the cache provider. All caches are configured with LRU (Least Recently Used) eviction policy.

Changes:
- Add spring-boot-starter-cache and caffeine dependencies
- Create CacheConfiguration with 5 separate caches:
  - graphs: for findAll results
  - graphById: for individual graph lookups
  - immutableGraphs: for immutable graph findAll
  - immutableGraphById: for individual immutable graph lookups
  - featureFlags: for feature flag values (with 5-min TTL)
- Add @Cacheable annotations to read operations
- Add @CacheEvict annotations to write operations
- Add comprehensive tests following TDD approach