### PR TITLE
chore: upgrade Spring Boot 3.4.1 to 3.5.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.5.16</version>
         <relativePath/>
     </parent>
 
@@ -27,7 +27,7 @@
         <archunit.version>1.3.0</archunit.version>
         <openfeature.version>1.12.0</openfeature.version>
         <resilience4j.version>2.2.0</resilience4j.version>
-        <springdoc.version>2.7.0</springdoc.version>
+        <springdoc.version>2.8.16</springdoc.version>
         <opentelemetry.version>1.44.1</opentelemetry.version>
     </properties>
 


### PR DESCRIPTION
Upgrade to the final Spring Boot 3.x release (3.5.16) which includes:
- Security patches and bug fixes
- Performance improvements
- Updated Spring Framework 6.2.x

Also updates springdoc-openapi from 2.7.0 to 2.8.16 for compatibility.

Note: Spring Boot 4.0+ requires Java 21. This project remains on Java 17, so 3.5.16 is the appropriate target version.


Claude-Session: https://claude.ai/code/session_01K5ingZTwDgJLZUpe47Qhcf